### PR TITLE
debugging for maple with linux

### DIFF
--- a/flint-extras/Makefile.in
+++ b/flint-extras/Makefile.in
@@ -798,11 +798,18 @@ ifneq ($(STATIC), 0)
 endif
 	$(CP) $(HEADERS) $(DESTDIR)$(INCLUDEDIR)/pml
 ifeq ($(WANT_MAPLE), 1)
+ifeq (darwin, $(findstring darwin, $(HOST_OS)))
 	$(CP_A) $(ABS_SRC_DIR)/mapml/mapml.mpl.bak $(BUILD_DIR)/mapml
 	$(CP_A) $(ABS_SRC_DIR)/mapml/maple-path.sh $(BUILD_DIR)/mapml
-	$(CD) $(BUILD_DIR)/mapml && sh maple-path.sh "$(prefix)"  "$(prefix)"
+	$(CD) $(BUILD_DIR)/mapml && sh maple-path.sh "$(prefix)/lib/libpml.dylib"  "$(prefix)/lib/libpml.dylib"
+	$(CP) $(BUILD_DIR)/mapml/mapml.mpl $(DESTDIR)$(INCLUDEDIR)/pml 
+else 
+	$(CP_A) $(ABS_SRC_DIR)/mapml/mapml.mpl.bak $(BUILD_DIR)/mapml
+	$(CP_A) $(ABS_SRC_DIR)/mapml/maple-path.sh $(BUILD_DIR)/mapml
+	$(CD) $(BUILD_DIR)/mapml && sh maple-path.sh "$(prefix)/lib/libpml.so"  "$(prefix)/lib/libpml.so"
 	$(CP) $(BUILD_DIR)/mapml/mapml.mpl $(DESTDIR)$(INCLUDEDIR)/pml 
 endif
+endif 
 	@echo ""
 	@echo '############################################################'
 	@echo '# NOTE:                                                    #'

--- a/flint-extras/configure.ac
+++ b/flint-extras/configure.ac
@@ -1141,17 +1141,21 @@ submit a bug report to <https://github.com/vneiger/pml/issues/> so
 that we can either fix the issue or give a more proper error message.])])
 fi
 
-if test "$with_maple" = "yes";
-then 
-    AC_SEARCH_LIBS([MapleToInteger64],[maplec],,
-    [AC_MSG_ERROR(["MAPLE library was not found.  If you indeed have maple installed, please
-submit a bug report to <https://github.com/vneiger/pml/issues/> so
-that we can either fix the issue or give a more proper error message.])])
-fi
+# Not done for the moment, see LD_LIBRARY_PATH with ubuntu #GV Jeu 26 jui 2025 13:04:19 CEST
+#if test "$with_maple" = "yes";
+#then 
+#    AC_SEARCH_LIBS([MapleToInteger64],[maplec],,
+#    [AC_MSG_ERROR(["MAPLE library was not found.  If you indeed have maple installed, please
+#submit a bug report to <https://github.com/vneiger/pml/issues/> so
+#that we can either fix the issue or give a more proper error message.])])
+#fi
 
 if test "$with_maple" = "yes";
-then AC_SUBST(WANT_MAPLE,1)
-else AC_SUBST(WANT_MAPLE,0)
+then 
+AC_SUBST(WANT_MAPLE,1)
+LIBS="$LIBS -lmaplec"
+else 
+AC_SUBST(WANT_MAPLE,0)
 fi
 
 ################################################################################

--- a/flint-extras/src/mapml/mapml.mpl.bak
+++ b/flint-extras/src/mapml/mapml.mpl.bak
@@ -39,11 +39,11 @@ mapml:= module()
 	
 	pmlpath := "path1"; 
 
-	mapmlpath := "path2";
+	mapmlpath := "path2";  # New version, not necessary in fact 
 
 	# How does maple find the other libraries? 
-	pml_lib := cat(pmlpath,"/lib/libpml.dylib");
-    mapml_lib := cat(mapmlpath,"/lib/libpml.dylib");
+	pml_lib := pmlpath; 
+    mapml_lib := mapmlpath; 
 
 	ModuleLoad:= proc( )
 		#define_external("nmod_poly_mat_init", MAPLE, LIB = "/usr/local/lib/libpml.dylib"):


### PR DESCRIPTION
.so instead of .dylib 
no check (without LD_LIBRARY_PATH) for the maple library 