### PR TITLE
Faster data movements in transpose-like operations

### DIFF
--- a/flint-extras/src/machine_vectors.h
+++ b/flint-extras/src/machine_vectors.h
@@ -137,5 +137,141 @@ FLINT_FORCE_INLINE ulong _mm512_hsum(__m512i a) {
 }
 #endif /* PML_HAVE_AVX512 */
 
+/*----------------------------------------------------*/
+/* small transposes of ulong blocks                   */
+/*----------------------------------------------------*/
+
+/* TODO these ulong lane shuffles, and the 4x4 transpose built from them, are
+ * the exact counterparts of vec4d_unpacklo, vec4d_unpackhi,
+ * vec4d_permute2_0_2, vec4d_permute2_1_3 and VEC4D_TRANSPOSE, which
+ * <flint/machine_vectors.h> already provides for both its AVX2 and its NEON
+ * backend; the ulong lane type simply has no lane-combining primitive there
+ * yet.  They belong next to their double counterparts in FLINT and should
+ * move there; they are kept here in the meantime. */
+#if PML_HAVE_MACHINE_VECTORS
+
+#if PML_HAVE_AVX2
+
+/* return {a[0], b[0], a[2], b[2]} */
+FLINT_FORCE_INLINE vec4n vec4n_unpacklo(vec4n a, vec4n b)
+{
+    return _mm256_unpacklo_epi64(a, b);
+}
+
+/* return {a[1], b[1], a[3], b[3]} */
+FLINT_FORCE_INLINE vec4n vec4n_unpackhi(vec4n a, vec4n b)
+{
+    return _mm256_unpackhi_epi64(a, b);
+}
+
+/* permute2_i0_i1(a, b): return {v[i0], v[i1]}
+                     |   v[0]     |    v[1]    |    v[2]    |   v[3]     |
+                       a[0], a[1]   a[2], a[3]   b[0], b[1]   b[2], b[3]  */
+FLINT_FORCE_INLINE vec4n vec4n_permute2_0_2(vec4n a, vec4n b)
+{
+    return _mm256_permute2x128_si256(a, b, 0 + 16 * 2);
+}
+
+FLINT_FORCE_INLINE vec4n vec4n_permute2_1_3(vec4n a, vec4n b)
+{
+    return _mm256_permute2x128_si256(a, b, 1 + 16 * 3);
+}
+
+#else  /* NEON: vec4n is a pair of uint64x2_t, as vec4d is a pair of
+          float64x2_t, and the same lane shuffles apply */
+
+/* return {a[0], b[0]} */
+FLINT_FORCE_INLINE vec2n vec2n_unpacklo(vec2n a, vec2n b)
+{
+    return vtrn1q_u64(a, b);
+}
+
+/* return {a[1], b[1]} */
+FLINT_FORCE_INLINE vec2n vec2n_unpackhi(vec2n a, vec2n b)
+{
+    return vtrn2q_u64(a, b);
+}
+
+/* return {a[0], b[0], a[2], b[2]} */
+FLINT_FORCE_INLINE vec4n vec4n_unpacklo(vec4n a, vec4n b)
+{
+    vec4n z = {vec2n_unpacklo(a.e1, b.e1), vec2n_unpacklo(a.e2, b.e2)};
+    return z;
+}
+
+/* return {a[1], b[1], a[3], b[3]} */
+FLINT_FORCE_INLINE vec4n vec4n_unpackhi(vec4n a, vec4n b)
+{
+    vec4n z = {vec2n_unpackhi(a.e1, b.e1), vec2n_unpackhi(a.e2, b.e2)};
+    return z;
+}
+
+/* return {a[0], a[1], b[0], b[1]} */
+FLINT_FORCE_INLINE vec4n vec4n_permute2_0_2(vec4n a, vec4n b)
+{
+    vec4n z = {a.e1, b.e1};
+    return z;
+}
+
+/* return {a[2], a[3], b[2], b[3]} */
+FLINT_FORCE_INLINE vec4n vec4n_permute2_1_3(vec4n a, vec4n b)
+{
+    vec4n z = {a.e2, b.e2};
+    return z;
+}
+
+#endif  /* PML_HAVE_AVX2 */
+
+/* view the 4 vectors as the rows of a 4x4 matrix */
+#define VEC4N_TRANSPOSE(z0, z1, z2, z3, a0, a1, a2, a3)                  \
+do {                                                                     \
+    vec4n _s0 = vec4n_unpacklo(a0, a1);                                  \
+    vec4n _s1 = vec4n_unpackhi(a0, a1);                                  \
+    vec4n _s2 = vec4n_unpacklo(a2, a3);                                  \
+    vec4n _s3 = vec4n_unpackhi(a2, a3);                                  \
+    z0 = vec4n_permute2_0_2(_s0, _s2);                                   \
+    z1 = vec4n_permute2_0_2(_s1, _s3);                                   \
+    z2 = vec4n_permute2_1_3(_s0, _s2);                                   \
+    z3 = vec4n_permute2_1_3(_s1, _s3);                                   \
+} while (0)
+
+#endif  /* PML_HAVE_MACHINE_VECTORS */
+
+/* 8x8 transpose of ulong blocks, AVX-512: 24 shuffle uops for 64 words. */
+#if PML_HAVE_AVX512
+
+/* view the 8 vectors as the rows of an 8x8 matrix; named arguments rather
+ * than arrays, as VEC4D_TRANSPOSE, so that nothing has to live in memory */
+#define VEC8N_TRANSPOSE(z0, z1, z2, z3, z4, z5, z6, z7,                  \
+                        a0, a1, a2, a3, a4, a5, a6, a7)                  \
+do {                                                                     \
+    __m512i _p0 = _mm512_unpacklo_epi64(a0, a1);                         \
+    __m512i _p1 = _mm512_unpackhi_epi64(a0, a1);                         \
+    __m512i _p2 = _mm512_unpacklo_epi64(a2, a3);                         \
+    __m512i _p3 = _mm512_unpackhi_epi64(a2, a3);                         \
+    __m512i _p4 = _mm512_unpacklo_epi64(a4, a5);                         \
+    __m512i _p5 = _mm512_unpackhi_epi64(a4, a5);                         \
+    __m512i _p6 = _mm512_unpacklo_epi64(a6, a7);                         \
+    __m512i _p7 = _mm512_unpackhi_epi64(a6, a7);                         \
+    __m512i _q0 = _mm512_shuffle_i64x2(_p0, _p2, 0x88);                  \
+    __m512i _q1 = _mm512_shuffle_i64x2(_p1, _p3, 0x88);                  \
+    __m512i _q2 = _mm512_shuffle_i64x2(_p0, _p2, 0xdd);                  \
+    __m512i _q3 = _mm512_shuffle_i64x2(_p1, _p3, 0xdd);                  \
+    __m512i _q4 = _mm512_shuffle_i64x2(_p4, _p6, 0x88);                  \
+    __m512i _q5 = _mm512_shuffle_i64x2(_p5, _p7, 0x88);                  \
+    __m512i _q6 = _mm512_shuffle_i64x2(_p4, _p6, 0xdd);                  \
+    __m512i _q7 = _mm512_shuffle_i64x2(_p5, _p7, 0xdd);                  \
+    z0 = _mm512_shuffle_i64x2(_q0, _q4, 0x88);                           \
+    z1 = _mm512_shuffle_i64x2(_q1, _q5, 0x88);                           \
+    z2 = _mm512_shuffle_i64x2(_q2, _q6, 0x88);                           \
+    z3 = _mm512_shuffle_i64x2(_q3, _q7, 0x88);                           \
+    z4 = _mm512_shuffle_i64x2(_q0, _q4, 0xdd);                           \
+    z5 = _mm512_shuffle_i64x2(_q1, _q5, 0xdd);                           \
+    z6 = _mm512_shuffle_i64x2(_q2, _q6, 0xdd);                           \
+    z7 = _mm512_shuffle_i64x2(_q3, _q7, 0xdd);                           \
+} while (0)
+
+#endif  /* PML_HAVE_AVX512 */
+
 
 #endif /* ifndef __MACHINE_VECTORS__H */

--- a/flint-extras/src/nmod_mat_poly.h
+++ b/flint-extras/src/nmod_mat_poly.h
@@ -671,13 +671,20 @@ void nmod_mat_poly_init_set_from_nmod_mat(nmod_mat_poly_t matp,
 void nmod_mat_poly_set_from_nmod_mat(nmod_mat_poly_t matp, const nmod_mat_t cmat);
 
 /** Set from polynomial with matrix coefficients `matp`, truncated at the
- * specified `order` (a nonnegative integer). */
+ * specified `order` (a nonnegative integer).
+ *
+ * This conversion is a transposition: writing `n = r*c` for the number of
+ * matrix entries, the input is an `n x order` array stored by rows (one
+ * contiguous coefficient array per polynomial entry) and the output is an
+ * `order x n` array stored by rows (one contiguous entry array per
+ * coefficient). It is performed by blocks, so that every cache line touched
+ * is read, respectively written, in full; see the implementation notes in
+ * `nmod_mat_poly_extra/nmod_mat_poly_set_from.c`. */
 void nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
                                       const nmod_poly_mat_t pmat,
                                       slong order);
 
 /** Set from polynomial with matrix coefficients `matp`. */
-// TODO benchmark and try variants if needed
 NMOD_MAT_POLY_INLINE void
 nmod_mat_poly_set_from_poly_mat(nmod_mat_poly_t matp, const nmod_poly_mat_t pmat)
 {

--- a/flint-extras/src/nmod_mat_poly_extra/impl.h
+++ b/flint-extras/src/nmod_mat_poly_extra/impl.h
@@ -25,8 +25,21 @@
 #define NMOD_MAT_POLY_CONV_VEC4   1  /* 4x4 blocks, FLINT machine vectors (AVX2, NEON) */
 #define NMOD_MAT_POLY_CONV_VEC8   2  /* 8x8 blocks, AVX-512 */
 
+/* Default loop schedule of the conversion: 1 for coefficient-major, 0 for
+ * entry-major.  Which one is faster depends on how much of a cache line one
+ * scattered store covers, and that makes Apple silicon (128-byte lines, and
+ * no kernel wider than 4 there) the odd one out; see the discussion in
+ * nmod_mat_poly_set_from.c.  Overridable at build time. */
+#ifndef PML_CONV_COEFF_MAJOR
+# if defined(__APPLE__) && defined(__aarch64__)
+#  define PML_CONV_COEFF_MAJOR 1
+# else
+#  define PML_CONV_COEFF_MAJOR 0
+# endif
+#endif
+
 /* Same as nmod_mat_poly_set_trunc_from_poly_mat, with explicit control over
- * the block kernel, the loop schedule and the prefetching
+ * the block kernel and the loop schedule.
  *
  * `kern` is one of NMOD_MAT_POLY_CONV_{SCALAR,VEC4,VEC8};
  * any other value selects the widest kernel the build provides, narrowed if
@@ -35,18 +48,12 @@
  * `cmaj` is 1 for the coefficient-major schedule (the blocks are visited so
  * that the stores into the output matrices are long sequential streams), 0
  * for the entry-major schedule (the loads from the input polynomials are long
- * sequential streams); any other value (e.g. -1) selects the default.
- *
- * `pf` is 1 to software-prefetch the side that is accessed one cache line per
- * row (the input polynomials under the coefficient-major schedule, the output
- * matrices under the entry-major one), 0 to disable it; any other value
- * (e.g. -1) enables it only when the data is large enough, see
- * PML_CONV_PREFETCH_BYTES. */
+ * sequential streams); any other value (e.g. -1) selects the default, which
+ * is PML_CONV_COEFF_MAJOR. */
 void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
                                             const nmod_poly_mat_t pmat,
                                             slong order,
                                             int kern,
-                                            int cmaj,
-                                            int pf);
+                                            int cmaj);
 
 #endif /* ifndef NMOD_MAT_POLY_EXTRA_IMPL_H */

--- a/flint-extras/src/nmod_mat_poly_extra/impl.h
+++ b/flint-extras/src/nmod_mat_poly_extra/impl.h
@@ -17,26 +17,66 @@
 
 #include "nmod_mat_poly.h"
 
-/* Block kernels for the nmod_poly_mat to nmod_mat_poly conversion: values for
- * the `kern` parameter of _nmod_mat_poly_set_trunc_from_poly_mat. A kernel
- * that the build does not provide is silently replaced by the widest
- * available one, so passing any of these is always safe. */
+/* Block kernels for the transposition that underlies both conversions
+ * between nmod_poly_mat and nmod_mat_poly: values for the `kern` parameter
+ * below.  A kernel that the build does not provide is silently replaced by
+ * the widest available one, so passing any of these is always safe. */
 #define NMOD_MAT_POLY_CONV_SCALAR 0  /* 8x8 blocks, no vector instructions */
 #define NMOD_MAT_POLY_CONV_VEC4   1  /* 4x4 blocks, FLINT machine vectors (AVX2, NEON) */
 #define NMOD_MAT_POLY_CONV_VEC8   2  /* 8x8 blocks, AVX-512 */
 
-/* Default loop schedule of the conversion: 1 for coefficient-major, 0 for
- * entry-major.  Which one is faster depends on how much of a cache line one
- * scattered store covers, and that makes Apple silicon (128-byte lines, and
- * no kernel wider than 4 there) the odd one out; see the discussion in
- * nmod_mat_poly_set_from.c.  Overridable at build time. */
-#ifndef PML_CONV_COEFF_MAJOR
+/* Default loop schedule: 1 to sweep the destination rows sequentially and
+ * scatter the loads, 0 to sweep the source rows sequentially and scatter the
+ * stores.  (For the nmod_poly_mat -> nmod_mat_poly direction the first is the
+ * coefficient-major schedule and the second the entry-major one; for the
+ * other direction the names swap, which is why they are not used here.)
+ *
+ * Which one wins depends on how much of a cache line one scattered store
+ * covers.  On x86, where a line is 64 bytes, a block is a whole line (8-wide
+ * kernel) or half of one (4-wide), the store needs no line to be kept around,
+ * and scattering the stores is nearly free: on Zen 4 that schedule is 1.6x to
+ * 2.4x faster from 16 MB of data upwards, and within noise below.
+ *
+ * On Apple silicon a line is 128 bytes and the widest kernel is the 4-wide
+ * NEON one, so a scattered store covers a quarter of a line: the line has to
+ * be fetched for ownership and then kept until the remaining quarters are
+ * written, which only happens after a full sweep of the inner loop.  That
+ * schedule then loses badly -- on an M4 it is 3x to 6x slower as soon as the
+ * matrix reaches 16x16, and slower than the naive loop itself from 32x32 on.
+ * With the stores sequential instead, consecutive blocks fill each line back
+ * to back and the line size stops mattering.
+ *
+ * Overridable at build time. */
+#ifndef PML_CONV_DST_MAJOR
 # if defined(__APPLE__) && defined(__aarch64__)
-#  define PML_CONV_COEFF_MAJOR 1
+#  define PML_CONV_DST_MAJOR 1
 # else
-#  define PML_CONV_COEFF_MAJOR 0
+#  define PML_CONV_DST_MAJOR 0
 # endif
 #endif
+
+/* Transposition between two collections of separately allocated rows:
+ *
+ *     dst[i][j] = (i < slen[j]) ? src[j][i] : 0,   i < ndst,  j < nsrc
+ *
+ * so `dst` has `ndst` rows of at least `nsrc` words each, and `src` has
+ * `nsrc` rows, row `j` holding `slen[j] <= ndst` words (the rest reads as
+ * zero and is never touched).  Pass `slen[j] == ndst` for every `j` when the
+ * source rows are all full.
+ *
+ * `kern` is one of NMOD_MAT_POLY_CONV_{SCALAR,VEC4,VEC8}, and must be a
+ * kernel whose block fits: see _pml_transpose_narrow_kernel.  `dmaj` is 1 for
+ * the destination-major schedule, 0 for the source-major one. */
+void _pml_transpose(nn_ptr * dst, slong ndst,
+                    nn_srcptr * src, const slong * slen, slong nsrc,
+                    int kern, int dmaj);
+
+/* Steps `kern` down to a kernel whose block fits inside a `ndst x nsrc`
+ * transposition, and returns it. */
+int _pml_transpose_narrow_kernel(int kern, slong ndst, slong nsrc);
+
+/* The widest kernel this build provides. */
+int _pml_transpose_widest_kernel(void);
 
 /* Same as nmod_mat_poly_set_trunc_from_poly_mat, with explicit control over
  * the block kernel and the loop schedule.
@@ -45,15 +85,14 @@
  * any other value selects the widest kernel the build provides, narrowed if
  * its block does not fit inside the problem.
  *
- * `cmaj` is 1 for the coefficient-major schedule (the blocks are visited so
- * that the stores into the output matrices are long sequential streams), 0
- * for the entry-major schedule (the loads from the input polynomials are long
- * sequential streams); any other value (e.g. -1) selects the default, which
- * is PML_CONV_COEFF_MAJOR. */
+ * `dmaj` is 1 for the coefficient-major schedule (the stores into the output
+ * matrices are long sequential streams), 0 for the entry-major schedule (the
+ * loads from the input polynomials are long sequential streams); any other
+ * value (e.g. -1) selects the default, PML_CONV_DST_MAJOR. */
 void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
                                             const nmod_poly_mat_t pmat,
                                             slong order,
                                             int kern,
-                                            int cmaj);
+                                            int dmaj);
 
 #endif /* ifndef NMOD_MAT_POLY_EXTRA_IMPL_H */

--- a/flint-extras/src/nmod_mat_poly_extra/impl.h
+++ b/flint-extras/src/nmod_mat_poly_extra/impl.h
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2026 Vincent Neiger
+
+    This file is part of PML.
+
+    PML is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License version 2.0 (GPL-2.0-or-later)
+    as published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version. See
+    <https://www.gnu.org/licenses/>.
+*/
+
+#ifndef NMOD_MAT_POLY_EXTRA_IMPL_H
+#define NMOD_MAT_POLY_EXTRA_IMPL_H
+
+#include <flint/nmod_types.h>
+
+#include "nmod_mat_poly.h"
+
+/* Block kernels for the nmod_poly_mat to nmod_mat_poly conversion: values for
+ * the `kern` parameter of _nmod_mat_poly_set_trunc_from_poly_mat. A kernel
+ * that the build does not provide is silently replaced by the widest
+ * available one, so passing any of these is always safe. */
+#define NMOD_MAT_POLY_CONV_SCALAR 0  /* 8x8 blocks, no vector instructions */
+#define NMOD_MAT_POLY_CONV_VEC4   1  /* 4x4 blocks, FLINT machine vectors (AVX2, NEON) */
+#define NMOD_MAT_POLY_CONV_VEC8   2  /* 8x8 blocks, AVX-512 */
+
+/* Same as nmod_mat_poly_set_trunc_from_poly_mat, with explicit control over
+ * the block kernel, the loop schedule and the prefetching
+ *
+ * `kern` is one of NMOD_MAT_POLY_CONV_{SCALAR,VEC4,VEC8};
+ * any other value selects the widest kernel the build provides, narrowed if
+ * its block does not fit inside the problem.
+ *
+ * `cmaj` is 1 for the coefficient-major schedule (the blocks are visited so
+ * that the stores into the output matrices are long sequential streams), 0
+ * for the entry-major schedule (the loads from the input polynomials are long
+ * sequential streams); any other value (e.g. -1) selects the default.
+ *
+ * `pf` is 1 to software-prefetch the side that is accessed one cache line per
+ * row (the input polynomials under the coefficient-major schedule, the output
+ * matrices under the entry-major one), 0 to disable it; any other value
+ * (e.g. -1) enables it only when the data is large enough, see
+ * PML_CONV_PREFETCH_BYTES. */
+void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
+                                            const nmod_poly_mat_t pmat,
+                                            slong order,
+                                            int kern,
+                                            int cmaj,
+                                            int pf);
+
+#endif /* ifndef NMOD_MAT_POLY_EXTRA_IMPL_H */

--- a/flint-extras/src/nmod_mat_poly_extra/nmod_mat_poly_set_from.c
+++ b/flint-extras/src/nmod_mat_poly_extra/nmod_mat_poly_set_from.c
@@ -1,4 +1,8 @@
+#include <string.h>  // for memcpy, memset
+
+#include "machine_vectors.h"
 #include "nmod_mat_poly.h"
+#include "nmod_mat_poly_extra/impl.h"
 #include <flint/nmod_poly.h>
 #include <flint/nmod_poly_mat.h>
 
@@ -32,9 +36,301 @@ void nmod_mat_poly_set_from_nmod_mat(nmod_mat_poly_t matp,
     }
 }
 
-void nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
-                                           const nmod_poly_mat_t pmat,
-                                           slong order)
+/*------------------------------------------------------------------------*/
+/* Conversion nmod_poly_mat -> nmod_mat_poly                               */
+/*                                                                         */
+/* This is a transposition.  Writing `n = r*c` for the number of matrix     */
+/* entries and `len` for the number of coefficients, the input is an        */
+/* `n x len` array whose rows (the coefficient arrays of the polynomial     */
+/* entries) are contiguous, and the output is a `len x n` array whose rows  */
+/* (the entry arrays of the matrix coefficients) are contiguous.  Both      */
+/* sides are collections of separately allocated rows.                      */
+/*                                                                         */
+/* The naive element-by-element loop uses 8 bytes of each 64-byte line it   */
+/* touches on one of the two sides before moving on, so as soon as that     */
+/* side stops fitting in cache it pays a miss per *word* instead of per     */
+/* cache line: an 8x read amplification.  The routines below move a `WxW`   */
+/* block at a time, `W = 4` or `8`, so that every cache line touched is     */
+/* read, or written, in full.                                              */
+/*                                                                         */
+/* The output rows being 64-byte aligned (see ::_nmod_mat_poly_coeff_alloc) */
+/* is what makes the 8-wide kernel worth having: a 64-byte store lands on   */
+/* one cache line rather than straddling two, which it would do at every    */
+/* single store if the rows were only 16-byte aligned, as a plain           */
+/* `flint_calloc` leaves them.                                             */
+/*------------------------------------------------------------------------*/
+
+/* Load W words of `s` starting at index `k`, zero-padding past `l`.
+   `l` is the (already truncated) length of the source polynomial: reading
+   at or beyond it is not allowed, the coefficients there are not stored. */
+#define _PML_LOADPAD(buf, s, l, k, W)                                        \
+    do {                                                                     \
+        const slong _av = (l) - (k);                                         \
+        if (_av >= (W))                                                      \
+            memcpy((buf), (s) + (k), (W) * sizeof(ulong));                   \
+        else                                                                 \
+        {                                                                    \
+            memset((buf), 0, (W) * sizeof(ulong));                           \
+            if (_av > 0)                                                     \
+                memcpy((buf), (s) + (k), (size_t) _av * sizeof(ulong));      \
+        }                                                                    \
+    } while (0)
+
+/* --- 8x8 scalar kernel (portable fallback) --- */
+#define _PML_KERNEL_SCALAR(e, k)                                             \
+    do {                                                                     \
+        ulong _b[8][8];                                                      \
+        for (slong _t = 0; _t < 8; _t++)                                     \
+            _PML_LOADPAD(_b[_t], src[(e) + _t], slen[(e) + _t], (k), 8);     \
+        for (slong _u = 0; _u < 8; _u++)                                     \
+        {                                                                    \
+            nn_ptr _d = dst[(k) + _u] + (e);                                 \
+            for (slong _t = 0; _t < 8; _t++)                                 \
+                _d[_t] = _b[_t][_u];                                         \
+        }                                                                    \
+    } while (0)
+
+/* --- 4x4 kernel on ulong machine vectors: AVX2 and NEON --- */
+#if PML_HAVE_MACHINE_VECTORS
+# define _PML_HAVE_CONV_VEC4 1
+
+FLINT_FORCE_INLINE vec4n _pml_conv_load4(nn_srcptr s, slong l, slong k)
+{
+    if (k + 4 <= l)
+        return vec4n_load_unaligned(s + k);
+    ulong b[4];
+    _PML_LOADPAD(b, s, l, k, 4);
+    return vec4n_load_unaligned(b);
+}
+
+#define _PML_KERNEL_VEC4(e, k)                                               \
+    do {                                                                     \
+        vec4n _a0 = _pml_conv_load4(src[(e) + 0], slen[(e) + 0], (k));       \
+        vec4n _a1 = _pml_conv_load4(src[(e) + 1], slen[(e) + 1], (k));       \
+        vec4n _a2 = _pml_conv_load4(src[(e) + 2], slen[(e) + 2], (k));       \
+        vec4n _a3 = _pml_conv_load4(src[(e) + 3], slen[(e) + 3], (k));       \
+        vec4n _z0, _z1, _z2, _z3;                                            \
+        VEC4N_TRANSPOSE(_z0, _z1, _z2, _z3, _a0, _a1, _a2, _a3);             \
+        vec4n_store_unaligned(dst[(k) + 0] + (e), _z0);                      \
+        vec4n_store_unaligned(dst[(k) + 1] + (e), _z1);                      \
+        vec4n_store_unaligned(dst[(k) + 2] + (e), _z2);                      \
+        vec4n_store_unaligned(dst[(k) + 3] + (e), _z3);                      \
+    } while (0)
+#endif  /* _PML_HAVE_CONV_VEC4 */
+
+/* --- 8x8 kernel, AVX-512 --- */
+#if PML_HAVE_AVX512
+# define _PML_HAVE_CONV_VEC8 1
+
+FLINT_FORCE_INLINE __m512i _pml_conv_load8(nn_srcptr s, slong l, slong k)
+{
+    if (k + 8 <= l)
+        return _mm512_loadu_si512((const void *) (s + k));
+    ulong b[8];
+    _PML_LOADPAD(b, s, l, k, 8);
+    return _mm512_loadu_si512((const void *) b);
+}
+
+#define _PML_KERNEL_VEC8(e, k)                                               \
+    do {                                                                     \
+        __m512i _a0 = _pml_conv_load8(src[(e) + 0], slen[(e) + 0], (k));     \
+        __m512i _a1 = _pml_conv_load8(src[(e) + 1], slen[(e) + 1], (k));     \
+        __m512i _a2 = _pml_conv_load8(src[(e) + 2], slen[(e) + 2], (k));     \
+        __m512i _a3 = _pml_conv_load8(src[(e) + 3], slen[(e) + 3], (k));     \
+        __m512i _a4 = _pml_conv_load8(src[(e) + 4], slen[(e) + 4], (k));     \
+        __m512i _a5 = _pml_conv_load8(src[(e) + 5], slen[(e) + 5], (k));     \
+        __m512i _a6 = _pml_conv_load8(src[(e) + 6], slen[(e) + 6], (k));     \
+        __m512i _a7 = _pml_conv_load8(src[(e) + 7], slen[(e) + 7], (k));     \
+        __m512i _z0, _z1, _z2, _z3, _z4, _z5, _z6, _z7;                      \
+        VEC8N_TRANSPOSE(_z0, _z1, _z2, _z3, _z4, _z5, _z6, _z7,              \
+                        _a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7);             \
+        _mm512_storeu_si512((void *) (dst[(k) + 0] + (e)), _z0);             \
+        _mm512_storeu_si512((void *) (dst[(k) + 1] + (e)), _z1);             \
+        _mm512_storeu_si512((void *) (dst[(k) + 2] + (e)), _z2);             \
+        _mm512_storeu_si512((void *) (dst[(k) + 3] + (e)), _z3);             \
+        _mm512_storeu_si512((void *) (dst[(k) + 4] + (e)), _z4);             \
+        _mm512_storeu_si512((void *) (dst[(k) + 5] + (e)), _z5);             \
+        _mm512_storeu_si512((void *) (dst[(k) + 6] + (e)), _z6);             \
+        _mm512_storeu_si512((void *) (dst[(k) + 7] + (e)), _z7);             \
+    } while (0)
+#endif  /* _PML_HAVE_CONV_VEC8 */
+
+/* Software prefetching.
+ *
+ * Whichever schedule is used, one of the two sides is visited one cache line
+ * per row, from rows that are separately allocated: an access pattern the
+ * hardware prefetchers cannot follow, so every one of those accesses is a
+ * demand miss (plus, beyond a few thousand rows, a page walk).  The addresses
+ * are all known in advance -- they are in the pointer tables -- so they can be
+ * prefetched a few blocks ahead.  Measured on a Skylake-SP this is worth 8% to
+ * 30% from about 1 MiB of data upwards, and is a small loss below, hence the
+ * size test in _nmod_mat_poly_set_trunc_from_poly_mat. */
+#if defined(__GNUC__) || defined(__clang__)
+# define _PML_PREFETCH_R(p) __builtin_prefetch((const void *) (p), 0, 3)
+# define _PML_PREFETCH_W(p) __builtin_prefetch((const void *) (p), 1, 3)
+#else
+# define _PML_PREFETCH_R(p) ((void) 0)
+# define _PML_PREFETCH_W(p) ((void) 0)
+#endif
+
+/* how far ahead, counted in rows of the scattered side */
+#define _PML_CONV_PFD 32
+
+/* Body shared by all instantiations.
+
+   COEFF_MAJOR == 1: the coefficient index is the outer loop, so the stores
+   walk each output matrix from left to right (long sequential write streams,
+   scattered reads).  COEFF_MAJOR == 0 is the transposed schedule (long
+   sequential read streams, scattered writes).
+
+   Whichever schedule is used, the residual bands are finished with plain
+   scalar loops; they are at most W-1 wide.  */
+#define _PML_CONV_BODY(W, KERNEL, COEFF_MAJOR, PF)                           \
+    const slong nW = n - (n % (W));                                          \
+    const slong lW = len - (len % (W));                                      \
+                                                                             \
+    if (COEFF_MAJOR)                                                         \
+    {                                                                        \
+        for (slong k = 0; k < lW; k += (W))                                  \
+            for (slong e = 0; e < nW; e += (W))                              \
+            {                                                                \
+                if (PF)                                                      \
+                {                                                            \
+                    const slong ep = (e + _PML_CONV_PFD < nW)                \
+                                   ? e + _PML_CONV_PFD : e;                  \
+                    for (slong _t = 0; _t < (W); _t++)                       \
+                        _PML_PREFETCH_R(src[ep + _t] + k);                   \
+                }                                                            \
+                KERNEL(e, k);                                                \
+            }                                                                \
+    }                                                                        \
+    else                                                                     \
+    {                                                                        \
+        for (slong e = 0; e < nW; e += (W))                                  \
+            for (slong k = 0; k < lW; k += (W))                              \
+            {                                                                \
+                if (PF)                                                      \
+                {                                                            \
+                    const slong kp = (k + _PML_CONV_PFD < lW)                \
+                                   ? k + _PML_CONV_PFD : k;                  \
+                    for (slong _u = 0; _u < (W); _u++)                       \
+                        _PML_PREFETCH_W(dst[kp + _u] + e);                   \
+                }                                                            \
+                KERNEL(e, k);                                                \
+            }                                                                \
+    }                                                                        \
+                                                                             \
+    for (slong k = lW; k < len; k++)                                         \
+    {                                                                        \
+        nn_ptr d = dst[k];                                                   \
+        for (slong e = 0; e < n; e++)                                        \
+            d[e] = (k < slen[e]) ? src[e][k] : UWORD(0);                     \
+    }                                                                        \
+    for (slong e = nW; e < n; e++)                                           \
+    {                                                                        \
+        nn_srcptr s = src[e];                                                \
+        const slong l = FLINT_MIN(slen[e], lW);                              \
+        for (slong k = 0; k < l; k++)                                        \
+            dst[k][e] = s[k];                                                \
+        for (slong k = l; k < lW; k++)                                       \
+            dst[k][e] = UWORD(0);                                            \
+    }
+
+#define _PML_MK_CONV(NAME, W, KERNEL, COEFF_MAJOR, PF)                       \
+static void NAME(nn_ptr * dst, slong len,                                    \
+                 nn_srcptr * src, const slong * slen, slong n)               \
+{                                                                            \
+    _PML_CONV_BODY(W, KERNEL, COEFF_MAJOR, PF)                               \
+}
+
+_PML_MK_CONV(_pml_conv_sca_cm, 8, _PML_KERNEL_SCALAR, 1, 0)
+_PML_MK_CONV(_pml_conv_sca_em, 8, _PML_KERNEL_SCALAR, 0, 0)
+_PML_MK_CONV(_pml_conv_sca_cm_pf, 8, _PML_KERNEL_SCALAR, 1, 1)
+_PML_MK_CONV(_pml_conv_sca_em_pf, 8, _PML_KERNEL_SCALAR, 0, 1)
+#if _PML_HAVE_CONV_VEC4
+_PML_MK_CONV(_pml_conv_v4_cm, 4, _PML_KERNEL_VEC4, 1, 0)
+_PML_MK_CONV(_pml_conv_v4_em, 4, _PML_KERNEL_VEC4, 0, 0)
+_PML_MK_CONV(_pml_conv_v4_cm_pf, 4, _PML_KERNEL_VEC4, 1, 1)
+_PML_MK_CONV(_pml_conv_v4_em_pf, 4, _PML_KERNEL_VEC4, 0, 1)
+#endif
+#if _PML_HAVE_CONV_VEC8
+_PML_MK_CONV(_pml_conv_v8_cm, 8, _PML_KERNEL_VEC8, 1, 0)
+_PML_MK_CONV(_pml_conv_v8_em, 8, _PML_KERNEL_VEC8, 0, 0)
+_PML_MK_CONV(_pml_conv_v8_cm_pf, 8, _PML_KERNEL_VEC8, 1, 1)
+_PML_MK_CONV(_pml_conv_v8_em_pf, 8, _PML_KERNEL_VEC8, 0, 1)
+#endif
+
+/* dispatch on (kernel, schedule, prefetch) */
+static void _pml_conv(nn_ptr * dst, slong len, nn_srcptr * src,
+                      const slong * slen, slong n, int kern, int cmaj, int pf)
+{
+#if _PML_HAVE_CONV_VEC8
+    if (kern == NMOD_MAT_POLY_CONV_VEC8)
+    {
+        if (cmaj) { if (pf) _pml_conv_v8_cm_pf(dst, len, src, slen, n);
+                    else    _pml_conv_v8_cm(dst, len, src, slen, n); }
+        else      { if (pf) _pml_conv_v8_em_pf(dst, len, src, slen, n);
+                    else    _pml_conv_v8_em(dst, len, src, slen, n); }
+        return;
+    }
+#endif
+#if _PML_HAVE_CONV_VEC4
+    if (kern == NMOD_MAT_POLY_CONV_VEC4)
+    {
+        if (cmaj) { if (pf) _pml_conv_v4_cm_pf(dst, len, src, slen, n);
+                    else    _pml_conv_v4_cm(dst, len, src, slen, n); }
+        else      { if (pf) _pml_conv_v4_em_pf(dst, len, src, slen, n);
+                    else    _pml_conv_v4_em(dst, len, src, slen, n); }
+        return;
+    }
+#endif
+    if (cmaj) { if (pf) _pml_conv_sca_cm_pf(dst, len, src, slen, n);
+                else    _pml_conv_sca_cm(dst, len, src, slen, n); }
+    else      { if (pf) _pml_conv_sca_em_pf(dst, len, src, slen, n);
+                else    _pml_conv_sca_em(dst, len, src, slen, n); }
+}
+
+/* Default kernel: the widest one the build provides.
+ *
+ * Measured on a Skylake-SP, with the output rows 64-byte aligned as
+ * nmod_mat_poly now allocates them, the 8-wide AVX-512 kernel is 10% to 40%
+ * faster than the 4-wide one on every shape tested -- and that is a lower
+ * bound for the machines PML_HAVE_AVX512 selects, since those have IFMA, hence
+ * are Ice Lake or later or Zen 4 or later, and do not pay the 512-bit
+ * frequency licence that Skylake-SP pays here.  (Before the coefficients were
+ * 64-byte aligned the ranking was the other way round, by a similar margin:
+ * every 64-byte store then straddled two cache lines.) */
+static int _pml_conv_default_kernel(void)
+{
+#if _PML_HAVE_CONV_VEC8
+    return NMOD_MAT_POLY_CONV_VEC8;
+#elif _PML_HAVE_CONV_VEC4
+    return NMOD_MAT_POLY_CONV_VEC4;
+#else
+    return NMOD_MAT_POLY_CONV_SCALAR;
+#endif
+}
+
+/*------------------------------------------------------------------------*/
+/* blocked implementation                                                  */
+/*------------------------------------------------------------------------*/
+
+/* Below this many words the pointer tables and their allocation dominate;
+   just run the naive loop. */
+#define _PML_CONV_TINY 512
+
+/* Above this many bytes of input, prefetch the scattered side (see above).
+   Measured crossover on a Skylake-SP is between 256 KiB and 1 MiB. */
+#ifndef PML_CONV_PREFETCH_BYTES
+# define PML_CONV_PREFETCH_BYTES (1024 * 1024)
+#endif
+
+void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
+                                            const nmod_poly_mat_t pmat,
+                                            slong order,
+                                            int kern,
+                                            int cmaj,
+                                            int pf)
 {
     const slong len = nmod_poly_mat_max_length(pmat);
     if (order > len)
@@ -44,16 +340,116 @@ void nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
     nmod_mat_poly_fit_length(matp, order);
     _nmod_mat_poly_set_length(matp, order);
 
-    // fill data
-    for (slong k = 0; k < order; k++)
-        for (slong i = 0; i < matp->r; i++)
-            for (slong j = 0; j < matp->c; j++)
-                nmod_mat_poly_entry(matp, k, i, j) = nmod_poly_get_coeff_ui(nmod_poly_mat_entry(pmat, i, j), k);
+    const slong r = matp->r;
+    const slong c = matp->c;
+
+    if (order == 0 || r == 0 || c == 0)
+    {
+        if (order < len)
+            _nmod_mat_poly_normalise(matp);
+        return;
+    }
+
+    if ((double) r * (double) c * (double) order < (double) _PML_CONV_TINY)
+    {
+        for (slong k = 0; k < order; k++)
+            for (slong i = 0; i < r; i++)
+                for (slong j = 0; j < c; j++)
+                    nmod_mat_poly_entry(matp, k, i, j) = nmod_poly_get_coeff_ui(nmod_poly_mat_entry(pmat, i, j), k);
+        if (order < len)
+            _nmod_mat_poly_normalise(matp);
+        return;
+    }
+
+    /* Effective number of "rows" of the transposition: the whole matrix when
+       the coefficients are contiguous, one matrix row otherwise. */
+    const slong nrows = (matp->stride == c) ? r * c : c;
+
+    if (kern < 0 || kern > NMOD_MAT_POLY_CONV_VEC8)
+        kern = _pml_conv_default_kernel();
+
+    /* A kernel whose block does not fit inside the problem would leave all
+       the work to the scalar residual bands, so step down to a narrower one.
+       This matters for small matrices: an 8x8 kernel does nothing at all on a
+       2x2 matrix (4 entries), where the 4x4 one is 4x faster. */
+    if (kern == NMOD_MAT_POLY_CONV_VEC8 && (nrows < 8 || order < 8))
+        kern = NMOD_MAT_POLY_CONV_VEC4;
+    if (kern == NMOD_MAT_POLY_CONV_VEC4 && (nrows < 4 || order < 4))
+        kern = NMOD_MAT_POLY_CONV_SCALAR;
+
+    /* Schedule.  Whichever loop is outermost, one side of the transposition
+       is visited in long sequential runs and the other one cache line at a
+       time, from rows that are separately allocated.
+
+       Entry-major is the default: it reads the input polynomials in long
+       sequential streams, which the hardware prefetchers follow for free, and
+       its scattered side is *stores* of one whole, 64-byte aligned cache line
+       each -- which is only cheap because the coefficients of an
+       nmod_mat_poly are aligned (see ::_nmod_mat_poly_coeff_alloc). With
+       16-byte aligned coefficients, as a plain flint_calloc leaves them,
+       every one of those stores straddled two cache lines and the ranking was
+       the other way round.
+
+       Measured on a Skylake-SP, entry-major is the faster schedule on every
+       shape tested from 2x2 to 128x128 and lengths 8 to 4096 but one isolated
+       pocket (1024 entries, length 2048, where the two power-of-two strides
+       conflict); its immediate neighbours in both directions prefer
+       entry-major again, so no special case is made for it. */
+    if (cmaj < 0 || cmaj > 1)
+        cmaj = 0;
+
+    /* Prefetch the scattered side -- the output matrices under the
+       entry-major schedule, the input polynomials under the other one -- as
+       soon as it no longer fits in the first cache levels. Pointless, and a
+       small loss, when that side has fewer rows than the prefetch distance,
+       since the prefetches then all land on rows already in flight. */
+    if (pf < 0 || pf > 1)
+        pf = ((double) r * (double) c * (double) order * sizeof(ulong)
+                  >= (double) PML_CONV_PREFETCH_BYTES)
+             && ((cmaj ? nrows : order) > _PML_CONV_PFD);
+
+    nn_srcptr * src = (nn_srcptr *) flint_malloc(r * c * sizeof(nn_srcptr));
+    slong * slen = (slong *) flint_malloc(r * c * sizeof(slong));
+
+    for (slong i = 0; i < r; i++)
+        for (slong j = 0; j < c; j++)
+        {
+            const nmod_poly_struct * p = nmod_poly_mat_entry(pmat, i, j);
+            src[i * c + j] = p->coeffs;
+            slen[i * c + j] = FLINT_MIN(p->length, order);
+        }
+
+    if (matp->stride == c)
+    {
+        /* the usual case: the entries of a coefficient are one contiguous run
+           of r*c words, 64-byte aligned, so the whole matrix is a single row
+           of the transposition */
+        _pml_conv(matp->coeffs, order, src, slen, r * c, kern, cmaj, pf);
+    }
+    else
+    {
+        /* padded or otherwise nonstandard stride: one transposition per row */
+        nn_ptr * dst = (nn_ptr *) flint_malloc(order * sizeof(nn_ptr));
+        for (slong i = 0; i < r; i++)
+        {
+            for (slong k = 0; k < order; k++)
+                dst[k] = matp->coeffs[k] + i * matp->stride;
+            _pml_conv(dst, order, src + i * c, slen + i * c, c, kern, cmaj, pf);
+        }
+        flint_free(dst);
+    }
+
+    flint_free(src);
+    flint_free(slen);
 
     // normalize (useless if order==len)
     if (order < len)
         _nmod_mat_poly_normalise(matp);
 }
 
-/* -*- mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- */
-// vim:sts=4:sw=4:ts=4:et:sr:cino=>s,f0,{0,g0,(0,\:0,t0,+0,=s
+void nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
+                                           const nmod_poly_mat_t pmat,
+                                           slong order)
+{
+    _nmod_mat_poly_set_trunc_from_poly_mat(matp, pmat, order, -1, -1, -1);
+}

--- a/flint-extras/src/nmod_mat_poly_extra/nmod_mat_poly_set_from.c
+++ b/flint-extras/src/nmod_mat_poly_extra/nmod_mat_poly_set_from.c
@@ -46,12 +46,14 @@ void nmod_mat_poly_set_from_nmod_mat(nmod_mat_poly_t matp,
 /* (the entry arrays of the matrix coefficients) are contiguous.  Both      */
 /* sides are collections of separately allocated rows.                      */
 /*                                                                         */
-/* The naive element-by-element loop uses 8 bytes of each 64-byte line it   */
+/* The naive element-by-element loop uses 8 bytes of each cache line it     */
 /* touches on one of the two sides before moving on, so as soon as that     */
 /* side stops fitting in cache it pays a miss per *word* instead of per     */
-/* cache line: an 8x read amplification.  The routines below move a `WxW`   */
-/* block at a time, `W = 4` or `8`, so that every cache line touched is     */
-/* read, or written, in full.                                              */
+/* cache line.  The routines below move a `WxW` block at a time, `W = 4` or */
+/* `8`, so that a whole cache line, or at least half of one, is filled at   */
+/* every visit.  Measured against the naive loop, that is worth 5x to 9x on */
+/* Zen 4 and 2x to 5x on Apple M4 over matrices 4x4 to 128x128 and lengths  */
+/* 32 to 2048.                                                             */
 /*                                                                         */
 /* The output rows being 64-byte aligned (see ::_nmod_mat_poly_coeff_alloc) */
 /* is what makes the 8-wide kernel worth having: a 64-byte store lands on   */
@@ -155,70 +157,30 @@ FLINT_FORCE_INLINE __m512i _pml_conv_load8(nn_srcptr s, slong l, slong k)
     } while (0)
 #endif  /* _PML_HAVE_CONV_VEC8 */
 
-/* Software prefetching.
- *
- * Whichever schedule is used, one of the two sides is visited one cache line
- * per row, from rows that are separately allocated: an access pattern the
- * hardware prefetchers cannot follow, so every one of those accesses is a
- * demand miss (plus, beyond a few thousand rows, a page walk).  The addresses
- * are all known in advance -- they are in the pointer tables -- so they can be
- * prefetched a few blocks ahead.  Measured on a Skylake-SP this is worth 8% to
- * 30% from about 1 MiB of data upwards, and is a small loss below, hence the
- * size test in _nmod_mat_poly_set_trunc_from_poly_mat. */
-#if defined(__GNUC__) || defined(__clang__)
-# define _PML_PREFETCH_R(p) __builtin_prefetch((const void *) (p), 0, 3)
-# define _PML_PREFETCH_W(p) __builtin_prefetch((const void *) (p), 1, 3)
-#else
-# define _PML_PREFETCH_R(p) ((void) 0)
-# define _PML_PREFETCH_W(p) ((void) 0)
-#endif
-
-/* how far ahead, counted in rows of the scattered side */
-#define _PML_CONV_PFD 32
-
-/* Body shared by all instantiations.
+/* One conversion routine, for a given block width, block kernel and schedule.
 
    COEFF_MAJOR == 1: the coefficient index is the outer loop, so the stores
    walk each output matrix from left to right (long sequential write streams,
    scattered reads).  COEFF_MAJOR == 0 is the transposed schedule (long
    sequential read streams, scattered writes).
 
-   Whichever schedule is used, the residual bands are finished with plain
-   scalar loops; they are at most W-1 wide.  */
-#define _PML_CONV_BODY(W, KERNEL, COEFF_MAJOR, PF)                           \
+   Either way the two residual bands, at most W-1 wide each, are finished with
+   plain scalar loops. */
+#define _PML_MK_CONV(NAME, W, KERNEL, COEFF_MAJOR)                           \
+static void NAME(nn_ptr * dst, slong len,                                    \
+                 nn_srcptr * src, const slong * slen, slong n)               \
+{                                                                            \
     const slong nW = n - (n % (W));                                          \
     const slong lW = len - (len % (W));                                      \
                                                                              \
     if (COEFF_MAJOR)                                                         \
-    {                                                                        \
         for (slong k = 0; k < lW; k += (W))                                  \
             for (slong e = 0; e < nW; e += (W))                              \
-            {                                                                \
-                if (PF)                                                      \
-                {                                                            \
-                    const slong ep = (e + _PML_CONV_PFD < nW)                \
-                                   ? e + _PML_CONV_PFD : e;                  \
-                    for (slong _t = 0; _t < (W); _t++)                       \
-                        _PML_PREFETCH_R(src[ep + _t] + k);                   \
-                }                                                            \
                 KERNEL(e, k);                                                \
-            }                                                                \
-    }                                                                        \
     else                                                                     \
-    {                                                                        \
         for (slong e = 0; e < nW; e += (W))                                  \
             for (slong k = 0; k < lW; k += (W))                              \
-            {                                                                \
-                if (PF)                                                      \
-                {                                                            \
-                    const slong kp = (k + _PML_CONV_PFD < lW)                \
-                                   ? k + _PML_CONV_PFD : k;                  \
-                    for (slong _u = 0; _u < (W); _u++)                       \
-                        _PML_PREFETCH_W(dst[kp + _u] + e);                   \
-                }                                                            \
                 KERNEL(e, k);                                                \
-            }                                                                \
-    }                                                                        \
                                                                              \
     for (slong k = lW; k < len; k++)                                         \
     {                                                                        \
@@ -234,72 +196,56 @@ FLINT_FORCE_INLINE __m512i _pml_conv_load8(nn_srcptr s, slong l, slong k)
             dst[k][e] = s[k];                                                \
         for (slong k = l; k < lW; k++)                                       \
             dst[k][e] = UWORD(0);                                            \
-    }
-
-#define _PML_MK_CONV(NAME, W, KERNEL, COEFF_MAJOR, PF)                       \
-static void NAME(nn_ptr * dst, slong len,                                    \
-                 nn_srcptr * src, const slong * slen, slong n)               \
-{                                                                            \
-    _PML_CONV_BODY(W, KERNEL, COEFF_MAJOR, PF)                               \
+    }                                                                        \
 }
 
-_PML_MK_CONV(_pml_conv_sca_cm, 8, _PML_KERNEL_SCALAR, 1, 0)
-_PML_MK_CONV(_pml_conv_sca_em, 8, _PML_KERNEL_SCALAR, 0, 0)
-_PML_MK_CONV(_pml_conv_sca_cm_pf, 8, _PML_KERNEL_SCALAR, 1, 1)
-_PML_MK_CONV(_pml_conv_sca_em_pf, 8, _PML_KERNEL_SCALAR, 0, 1)
+_PML_MK_CONV(_pml_conv_sca_cm, 8, _PML_KERNEL_SCALAR, 1)
+_PML_MK_CONV(_pml_conv_sca_em, 8, _PML_KERNEL_SCALAR, 0)
 #if _PML_HAVE_CONV_VEC4
-_PML_MK_CONV(_pml_conv_v4_cm, 4, _PML_KERNEL_VEC4, 1, 0)
-_PML_MK_CONV(_pml_conv_v4_em, 4, _PML_KERNEL_VEC4, 0, 0)
-_PML_MK_CONV(_pml_conv_v4_cm_pf, 4, _PML_KERNEL_VEC4, 1, 1)
-_PML_MK_CONV(_pml_conv_v4_em_pf, 4, _PML_KERNEL_VEC4, 0, 1)
+_PML_MK_CONV(_pml_conv_v4_cm, 4, _PML_KERNEL_VEC4, 1)
+_PML_MK_CONV(_pml_conv_v4_em, 4, _PML_KERNEL_VEC4, 0)
 #endif
 #if _PML_HAVE_CONV_VEC8
-_PML_MK_CONV(_pml_conv_v8_cm, 8, _PML_KERNEL_VEC8, 1, 0)
-_PML_MK_CONV(_pml_conv_v8_em, 8, _PML_KERNEL_VEC8, 0, 0)
-_PML_MK_CONV(_pml_conv_v8_cm_pf, 8, _PML_KERNEL_VEC8, 1, 1)
-_PML_MK_CONV(_pml_conv_v8_em_pf, 8, _PML_KERNEL_VEC8, 0, 1)
+_PML_MK_CONV(_pml_conv_v8_cm, 8, _PML_KERNEL_VEC8, 1)
+_PML_MK_CONV(_pml_conv_v8_em, 8, _PML_KERNEL_VEC8, 0)
 #endif
 
-/* dispatch on (kernel, schedule, prefetch) */
+/* dispatch on (kernel, schedule) */
 static void _pml_conv(nn_ptr * dst, slong len, nn_srcptr * src,
-                      const slong * slen, slong n, int kern, int cmaj, int pf)
+                      const slong * slen, slong n, int kern, int cmaj)
 {
 #if _PML_HAVE_CONV_VEC8
     if (kern == NMOD_MAT_POLY_CONV_VEC8)
     {
-        if (cmaj) { if (pf) _pml_conv_v8_cm_pf(dst, len, src, slen, n);
-                    else    _pml_conv_v8_cm(dst, len, src, slen, n); }
-        else      { if (pf) _pml_conv_v8_em_pf(dst, len, src, slen, n);
-                    else    _pml_conv_v8_em(dst, len, src, slen, n); }
+        if (cmaj) _pml_conv_v8_cm(dst, len, src, slen, n);
+        else      _pml_conv_v8_em(dst, len, src, slen, n);
         return;
     }
 #endif
 #if _PML_HAVE_CONV_VEC4
     if (kern == NMOD_MAT_POLY_CONV_VEC4)
     {
-        if (cmaj) { if (pf) _pml_conv_v4_cm_pf(dst, len, src, slen, n);
-                    else    _pml_conv_v4_cm(dst, len, src, slen, n); }
-        else      { if (pf) _pml_conv_v4_em_pf(dst, len, src, slen, n);
-                    else    _pml_conv_v4_em(dst, len, src, slen, n); }
+        if (cmaj) _pml_conv_v4_cm(dst, len, src, slen, n);
+        else      _pml_conv_v4_em(dst, len, src, slen, n);
         return;
     }
 #endif
-    if (cmaj) { if (pf) _pml_conv_sca_cm_pf(dst, len, src, slen, n);
-                else    _pml_conv_sca_cm(dst, len, src, slen, n); }
-    else      { if (pf) _pml_conv_sca_em_pf(dst, len, src, slen, n);
-                else    _pml_conv_sca_em(dst, len, src, slen, n); }
+    if (cmaj) _pml_conv_sca_cm(dst, len, src, slen, n);
+    else      _pml_conv_sca_em(dst, len, src, slen, n);
 }
 
 /* Default kernel: the widest one the build provides.
  *
- * Measured on a Skylake-SP, with the output rows 64-byte aligned as
- * nmod_mat_poly now allocates them, the 8-wide AVX-512 kernel is 10% to 40%
- * faster than the 4-wide one on every shape tested -- and that is a lower
- * bound for the machines PML_HAVE_AVX512 selects, since those have IFMA, hence
- * are Ice Lake or later or Zen 4 or later, and do not pay the 512-bit
- * frequency licence that Skylake-SP pays here.  (Before the coefficients were
- * 64-byte aligned the ranking was the other way round, by a similar margin:
- * every 64-byte store then straddled two cache lines.) */
+ * On Zen 4 the 8-wide AVX-512 kernel is 20% to 40% faster than the 4-wide one
+ * as long as the data fits in cache (0.20 vs 0.28 ns per word at 32x32 and
+ * length 128), and 10% to 20% slower once it does not (0.95 vs 0.86 at 64x64
+ * and length 2048).  The two are close enough overall that the wider one is
+ * kept for its advantage in the common, cache-resident range.
+ *
+ * The ranking depends on the output rows being 64-byte aligned, as
+ * ::_nmod_mat_poly_coeff_alloc makes them: with the 16-byte alignment a plain
+ * `flint_calloc` leaves, every 64-byte store straddles two cache lines and
+ * the 4-wide kernel wins instead. */
 static int _pml_conv_default_kernel(void)
 {
 #if _PML_HAVE_CONV_VEC8
@@ -319,18 +265,11 @@ static int _pml_conv_default_kernel(void)
    just run the naive loop. */
 #define _PML_CONV_TINY 512
 
-/* Above this many bytes of input, prefetch the scattered side (see above).
-   Measured crossover on a Skylake-SP is between 256 KiB and 1 MiB. */
-#ifndef PML_CONV_PREFETCH_BYTES
-# define PML_CONV_PREFETCH_BYTES (1024 * 1024)
-#endif
-
 void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
                                             const nmod_poly_mat_t pmat,
                                             slong order,
                                             int kern,
-                                            int cmaj,
-                                            int pf)
+                                            int cmaj)
 {
     const slong len = nmod_poly_mat_max_length(pmat);
     if (order > len)
@@ -378,35 +317,29 @@ void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
         kern = NMOD_MAT_POLY_CONV_SCALAR;
 
     /* Schedule.  Whichever loop is outermost, one side of the transposition
-       is visited in long sequential runs and the other one cache line at a
-       time, from rows that are separately allocated.
+       is visited in long sequential runs and the other one block at a time,
+       from rows that are separately allocated.  Entry-major puts the long
+       runs on the loads from the input polynomials and scatters the stores
+       into the output matrices; coefficient-major does the opposite.
 
-       Entry-major is the default: it reads the input polynomials in long
-       sequential streams, which the hardware prefetchers follow for free, and
-       its scattered side is *stores* of one whole, 64-byte aligned cache line
-       each -- which is only cheap because the coefficients of an
-       nmod_mat_poly are aligned (see ::_nmod_mat_poly_coeff_alloc). With
-       16-byte aligned coefficients, as a plain flint_calloc leaves them,
-       every one of those stores straddled two cache lines and the ranking was
-       the other way round.
+       Which one wins depends on how much of a cache line one scattered store
+       covers.  On x86, where a line is 64 bytes, a block is a whole line
+       (8-wide kernel) or half of one (4-wide), the store needs no line to be
+       kept around, and entry-major wins: on Zen 4 it is 1.6x to 2.4x faster
+       than coefficient-major from 16 MB of data upwards, and within noise
+       below.
 
-       Measured on a Skylake-SP, entry-major is the faster schedule on every
-       shape tested from 2x2 to 128x128 and lengths 8 to 4096 but one isolated
-       pocket (1024 entries, length 2048, where the two power-of-two strides
-       conflict); its immediate neighbours in both directions prefer
-       entry-major again, so no special case is made for it. */
+       On Apple silicon a line is 128 bytes, so a scattered store covers a
+       quarter of one (the 4-wide NEON kernel is the widest available there):
+       the line has to be fetched for ownership and then kept until the
+       remaining quarters are written, which only happens after a full sweep
+       of the inner loop.  Entry-major then loses badly -- on an M4 it is 3x
+       to 6x slower than coefficient-major as soon as the matrix reaches
+       16x16, and slower than the naive loop itself from 32x32 on.  With the
+       stores sequential instead, consecutive blocks fill each line back to
+       back and the line size stops mattering. */
     if (cmaj < 0 || cmaj > 1)
-        cmaj = 0;
-
-    /* Prefetch the scattered side -- the output matrices under the
-       entry-major schedule, the input polynomials under the other one -- as
-       soon as it no longer fits in the first cache levels. Pointless, and a
-       small loss, when that side has fewer rows than the prefetch distance,
-       since the prefetches then all land on rows already in flight. */
-    if (pf < 0 || pf > 1)
-        pf = ((double) r * (double) c * (double) order * sizeof(ulong)
-                  >= (double) PML_CONV_PREFETCH_BYTES)
-             && ((cmaj ? nrows : order) > _PML_CONV_PFD);
+        cmaj = PML_CONV_COEFF_MAJOR;
 
     nn_srcptr * src = (nn_srcptr *) flint_malloc(r * c * sizeof(nn_srcptr));
     slong * slen = (slong *) flint_malloc(r * c * sizeof(slong));
@@ -424,7 +357,7 @@ void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
         /* the usual case: the entries of a coefficient are one contiguous run
            of r*c words, 64-byte aligned, so the whole matrix is a single row
            of the transposition */
-        _pml_conv(matp->coeffs, order, src, slen, r * c, kern, cmaj, pf);
+        _pml_conv(matp->coeffs, order, src, slen, r * c, kern, cmaj);
     }
     else
     {
@@ -434,7 +367,7 @@ void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
         {
             for (slong k = 0; k < order; k++)
                 dst[k] = matp->coeffs[k] + i * matp->stride;
-            _pml_conv(dst, order, src + i * c, slen + i * c, c, kern, cmaj, pf);
+            _pml_conv(dst, order, src + i * c, slen + i * c, c, kern, cmaj);
         }
         flint_free(dst);
     }
@@ -451,5 +384,5 @@ void nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
                                            const nmod_poly_mat_t pmat,
                                            slong order)
 {
-    _nmod_mat_poly_set_trunc_from_poly_mat(matp, pmat, order, -1, -1, -1);
+    _nmod_mat_poly_set_trunc_from_poly_mat(matp, pmat, order, -1, -1);
 }

--- a/flint-extras/src/nmod_mat_poly_extra/nmod_mat_poly_set_from.c
+++ b/flint-extras/src/nmod_mat_poly_extra/nmod_mat_poly_set_from.c
@@ -37,14 +37,17 @@ void nmod_mat_poly_set_from_nmod_mat(nmod_mat_poly_t matp,
 }
 
 /*------------------------------------------------------------------------*/
-/* Conversion nmod_poly_mat -> nmod_mat_poly                               */
+/* Transposition between two collections of separately allocated rows      */
 /*                                                                         */
-/* This is a transposition.  Writing `n = r*c` for the number of matrix     */
-/* entries and `len` for the number of coefficients, the input is an        */
-/* `n x len` array whose rows (the coefficient arrays of the polynomial     */
-/* entries) are contiguous, and the output is a `len x n` array whose rows  */
-/* (the entry arrays of the matrix coefficients) are contiguous.  Both      */
-/* sides are collections of separately allocated rows.                      */
+/* Both conversions between nmod_poly_mat and nmod_mat_poly are the same    */
+/* transposition, with the two sides exchanged.  Writing `n = r*c` for the  */
+/* number of matrix entries and `len` for the number of coefficients, an    */
+/* nmod_poly_mat is an `n x len` array whose rows (the coefficient arrays   */
+/* of the polynomial entries) are contiguous, and an nmod_mat_poly is a     */
+/* `len x n` array whose rows (the entry arrays of the matrix coefficients) */
+/* are contiguous.  ::_pml_transpose does one such transposition and is     */
+/* used by both directions; only which table is passed as the source and    */
+/* which as the destination differs.                                       */
 /*                                                                         */
 /* The naive element-by-element loop uses 8 bytes of each cache line it     */
 /* touches on one of the two sides before moving on, so as soon as that     */
@@ -55,11 +58,12 @@ void nmod_mat_poly_set_from_nmod_mat(nmod_mat_poly_t matp,
 /* Zen 4 and 2x to 5x on Apple M4 over matrices 4x4 to 128x128 and lengths  */
 /* 32 to 2048.                                                             */
 /*                                                                         */
-/* The output rows being 64-byte aligned (see ::_nmod_mat_poly_coeff_alloc) */
-/* is what makes the 8-wide kernel worth having: a 64-byte store lands on   */
-/* one cache line rather than straddling two, which it would do at every    */
-/* single store if the rows were only 16-byte aligned, as a plain           */
-/* `flint_calloc` leaves them.                                             */
+/* Alignment decides how wide a kernel is worth using, and the two          */
+/* directions differ there: the coefficients of an nmod_mat_poly are        */
+/* 64-byte aligned (see ::_nmod_mat_poly_coeff_alloc) so a 64-byte access   */
+/* lands on one cache line, while the coefficient array of an nmod_poly is  */
+/* whatever `flint_realloc` returns, so the same access straddles two.      */
+/* Hence the two conversions do not pick the same default kernel.          */
 /*------------------------------------------------------------------------*/
 
 /* Load W words of `s` starting at index `k`, zero-padding past `l`.
@@ -157,23 +161,24 @@ FLINT_FORCE_INLINE __m512i _pml_conv_load8(nn_srcptr s, slong l, slong k)
     } while (0)
 #endif  /* _PML_HAVE_CONV_VEC8 */
 
-/* One conversion routine, for a given block width, block kernel and schedule.
+/* One transposition routine, for a given block width, block kernel and
+   schedule.
 
-   COEFF_MAJOR == 1: the coefficient index is the outer loop, so the stores
-   walk each output matrix from left to right (long sequential write streams,
-   scattered reads).  COEFF_MAJOR == 0 is the transposed schedule (long
-   sequential read streams, scattered writes).
+   DST_MAJOR == 1: the destination row index is the outer loop, so the stores
+   walk each destination row from left to right (long sequential write
+   streams, scattered reads).  DST_MAJOR == 0 is the transposed schedule
+   (long sequential read streams, scattered writes).
 
    Either way the two residual bands, at most W-1 wide each, are finished with
    plain scalar loops. */
-#define _PML_MK_CONV(NAME, W, KERNEL, COEFF_MAJOR)                           \
+#define _PML_MK_TRANSPOSE(NAME, W, KERNEL, DST_MAJOR)                           \
 static void NAME(nn_ptr * dst, slong len,                                    \
                  nn_srcptr * src, const slong * slen, slong n)               \
 {                                                                            \
     const slong nW = n - (n % (W));                                          \
     const slong lW = len - (len % (W));                                      \
                                                                              \
-    if (COEFF_MAJOR)                                                         \
+    if (DST_MAJOR)                                                         \
         for (slong k = 0; k < lW; k += (W))                                  \
             for (slong e = 0; e < nW; e += (W))                              \
                 KERNEL(e, k);                                                \
@@ -199,54 +204,56 @@ static void NAME(nn_ptr * dst, slong len,                                    \
     }                                                                        \
 }
 
-_PML_MK_CONV(_pml_conv_sca_cm, 8, _PML_KERNEL_SCALAR, 1)
-_PML_MK_CONV(_pml_conv_sca_em, 8, _PML_KERNEL_SCALAR, 0)
+_PML_MK_TRANSPOSE(_pml_tr_sca_dm, 8, _PML_KERNEL_SCALAR, 1)
+_PML_MK_TRANSPOSE(_pml_tr_sca_sm, 8, _PML_KERNEL_SCALAR, 0)
 #if _PML_HAVE_CONV_VEC4
-_PML_MK_CONV(_pml_conv_v4_cm, 4, _PML_KERNEL_VEC4, 1)
-_PML_MK_CONV(_pml_conv_v4_em, 4, _PML_KERNEL_VEC4, 0)
+_PML_MK_TRANSPOSE(_pml_tr_v4_dm, 4, _PML_KERNEL_VEC4, 1)
+_PML_MK_TRANSPOSE(_pml_tr_v4_sm, 4, _PML_KERNEL_VEC4, 0)
 #endif
 #if _PML_HAVE_CONV_VEC8
-_PML_MK_CONV(_pml_conv_v8_cm, 8, _PML_KERNEL_VEC8, 1)
-_PML_MK_CONV(_pml_conv_v8_em, 8, _PML_KERNEL_VEC8, 0)
+_PML_MK_TRANSPOSE(_pml_tr_v8_dm, 8, _PML_KERNEL_VEC8, 1)
+_PML_MK_TRANSPOSE(_pml_tr_v8_sm, 8, _PML_KERNEL_VEC8, 0)
 #endif
 
-/* dispatch on (kernel, schedule) */
-static void _pml_conv(nn_ptr * dst, slong len, nn_srcptr * src,
-                      const slong * slen, slong n, int kern, int cmaj)
+/* Dispatch on (kernel, schedule).  Documented in nmod_mat_poly_extra/impl.h. */
+void _pml_transpose(nn_ptr * dst, slong ndst, nn_srcptr * src,
+                    const slong * slen, slong nsrc, int kern, int dmaj)
 {
 #if _PML_HAVE_CONV_VEC8
     if (kern == NMOD_MAT_POLY_CONV_VEC8)
     {
-        if (cmaj) _pml_conv_v8_cm(dst, len, src, slen, n);
-        else      _pml_conv_v8_em(dst, len, src, slen, n);
+        if (dmaj) _pml_tr_v8_dm(dst, ndst, src, slen, nsrc);
+        else      _pml_tr_v8_sm(dst, ndst, src, slen, nsrc);
         return;
     }
 #endif
 #if _PML_HAVE_CONV_VEC4
     if (kern == NMOD_MAT_POLY_CONV_VEC4)
     {
-        if (cmaj) _pml_conv_v4_cm(dst, len, src, slen, n);
-        else      _pml_conv_v4_em(dst, len, src, slen, n);
+        if (dmaj) _pml_tr_v4_dm(dst, ndst, src, slen, nsrc);
+        else      _pml_tr_v4_sm(dst, ndst, src, slen, nsrc);
         return;
     }
 #endif
-    if (cmaj) _pml_conv_sca_cm(dst, len, src, slen, n);
-    else      _pml_conv_sca_em(dst, len, src, slen, n);
+    if (dmaj) _pml_tr_sca_dm(dst, ndst, src, slen, nsrc);
+    else      _pml_tr_sca_sm(dst, ndst, src, slen, nsrc);
 }
 
-/* Default kernel: the widest one the build provides.
- *
- * On Zen 4 the 8-wide AVX-512 kernel is 20% to 40% faster than the 4-wide one
- * as long as the data fits in cache (0.20 vs 0.28 ns per word at 32x32 and
- * length 128), and 10% to 20% slower once it does not (0.95 vs 0.86 at 64x64
- * and length 2048).  The two are close enough overall that the wider one is
- * kept for its advantage in the common, cache-resident range.
- *
- * The ranking depends on the output rows being 64-byte aligned, as
- * ::_nmod_mat_poly_coeff_alloc makes them: with the 16-byte alignment a plain
- * `flint_calloc` leaves, every 64-byte store straddles two cache lines and
- * the 4-wide kernel wins instead. */
-static int _pml_conv_default_kernel(void)
+/* Narrow `kern` to a kernel whose block fits inside a `ndst x nsrc`
+   transposition: a wider one would leave all the work to the scalar residual
+   bands.  This matters for small matrices -- an 8x8 kernel does nothing at
+   all on a 2x2 matrix (4 entries), where the 4x4 one is 4x faster. */
+int _pml_transpose_narrow_kernel(int kern, slong ndst, slong nsrc)
+{
+    if (kern == NMOD_MAT_POLY_CONV_VEC8 && (nsrc < 8 || ndst < 8))
+        kern = NMOD_MAT_POLY_CONV_VEC4;
+    if (kern == NMOD_MAT_POLY_CONV_VEC4 && (nsrc < 4 || ndst < 4))
+        kern = NMOD_MAT_POLY_CONV_SCALAR;
+    return kern;
+}
+
+/* The widest kernel this build provides. */
+int _pml_transpose_widest_kernel(void)
 {
 #if _PML_HAVE_CONV_VEC8
     return NMOD_MAT_POLY_CONV_VEC8;
@@ -269,7 +276,7 @@ void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
                                             const nmod_poly_mat_t pmat,
                                             slong order,
                                             int kern,
-                                            int cmaj)
+                                            int dmaj)
 {
     const slong len = nmod_poly_mat_max_length(pmat);
     if (order > len)
@@ -304,42 +311,27 @@ void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
        the coefficients are contiguous, one matrix row otherwise. */
     const slong nrows = (matp->stride == c) ? r * c : c;
 
+    /* Default kernel: the widest one available.  On Zen 4 the 8-wide AVX-512
+       kernel is 20% to 40% faster than the 4-wide one as long as the data
+       fits in cache (0.20 vs 0.28 ns per word at 32x32 and length 128), and
+       10% to 20% slower once it does not (0.95 vs 0.86 at 64x64 and length
+       2048); close enough overall to keep the wider one for its advantage in
+       the common, cache-resident range.  This relies on the destination rows
+       here being 64-byte aligned, as ::_nmod_mat_poly_coeff_alloc makes them;
+       the conversion in the other direction, whose destination rows are not,
+       makes a different choice. */
     if (kern < 0 || kern > NMOD_MAT_POLY_CONV_VEC8)
-        kern = _pml_conv_default_kernel();
+        kern = _pml_transpose_widest_kernel();
 
-    /* A kernel whose block does not fit inside the problem would leave all
-       the work to the scalar residual bands, so step down to a narrower one.
-       This matters for small matrices: an 8x8 kernel does nothing at all on a
-       2x2 matrix (4 entries), where the 4x4 one is 4x faster. */
-    if (kern == NMOD_MAT_POLY_CONV_VEC8 && (nrows < 8 || order < 8))
-        kern = NMOD_MAT_POLY_CONV_VEC4;
-    if (kern == NMOD_MAT_POLY_CONV_VEC4 && (nrows < 4 || order < 4))
-        kern = NMOD_MAT_POLY_CONV_SCALAR;
+    kern = _pml_transpose_narrow_kernel(kern, order, nrows);
 
-    /* Schedule.  Whichever loop is outermost, one side of the transposition
-       is visited in long sequential runs and the other one block at a time,
-       from rows that are separately allocated.  Entry-major puts the long
-       runs on the loads from the input polynomials and scatters the stores
-       into the output matrices; coefficient-major does the opposite.
-
-       Which one wins depends on how much of a cache line one scattered store
-       covers.  On x86, where a line is 64 bytes, a block is a whole line
-       (8-wide kernel) or half of one (4-wide), the store needs no line to be
-       kept around, and entry-major wins: on Zen 4 it is 1.6x to 2.4x faster
-       than coefficient-major from 16 MB of data upwards, and within noise
-       below.
-
-       On Apple silicon a line is 128 bytes, so a scattered store covers a
-       quarter of one (the 4-wide NEON kernel is the widest available there):
-       the line has to be fetched for ownership and then kept until the
-       remaining quarters are written, which only happens after a full sweep
-       of the inner loop.  Entry-major then loses badly -- on an M4 it is 3x
-       to 6x slower than coefficient-major as soon as the matrix reaches
-       16x16, and slower than the naive loop itself from 32x32 on.  With the
-       stores sequential instead, consecutive blocks fill each line back to
-       back and the line size stops mattering. */
-    if (cmaj < 0 || cmaj > 1)
-        cmaj = PML_CONV_COEFF_MAJOR;
+    /* Schedule; here destination-major is the coefficient-major schedule (the
+       stores walk each output matrix coefficient from left to right) and
+       source-major is the entry-major one (the loads walk each input
+       polynomial).  See nmod_mat_poly_extra/impl.h for why the default
+       depends on the target. */
+    if (dmaj < 0 || dmaj > 1)
+        dmaj = PML_CONV_DST_MAJOR;
 
     nn_srcptr * src = (nn_srcptr *) flint_malloc(r * c * sizeof(nn_srcptr));
     slong * slen = (slong *) flint_malloc(r * c * sizeof(slong));
@@ -357,7 +349,7 @@ void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
         /* the usual case: the entries of a coefficient are one contiguous run
            of r*c words, 64-byte aligned, so the whole matrix is a single row
            of the transposition */
-        _pml_conv(matp->coeffs, order, src, slen, r * c, kern, cmaj);
+        _pml_transpose(matp->coeffs, order, src, slen, r * c, kern, dmaj);
     }
     else
     {
@@ -367,7 +359,7 @@ void _nmod_mat_poly_set_trunc_from_poly_mat(nmod_mat_poly_t matp,
         {
             for (slong k = 0; k < order; k++)
                 dst[k] = matp->coeffs[k] + i * matp->stride;
-            _pml_conv(dst, order, src + i * c, slen + i * c, c, kern, cmaj);
+            _pml_transpose(dst, order, src + i * c, slen + i * c, c, kern, dmaj);
         }
         flint_free(dst);
     }

--- a/flint-extras/src/nmod_mat_poly_extra/profile/p-set_from_poly_mat.c
+++ b/flint-extras/src/nmod_mat_poly_extra/profile/p-set_from_poly_mat.c
@@ -1,0 +1,228 @@
+/*
+    Copyright (C) 2026 Vincent Neiger
+
+    This file is part of PML.
+
+    PML is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License version 2.0 (GPL-2.0-or-later)
+    as published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version. See
+    <https://www.gnu.org/licenses/>.
+*/
+
+/* Timings for the nmod_poly_mat -> nmod_mat_poly conversion.
+ *
+ * Unit: nanoseconds per converted word
+ *
+ * The conversion is a transposition of r*c*order words and moves 8 bytes in
+ * and 8 bytes out per word, so a value close to the cost of a plain memcpy of
+ * the same volume is the target. */
+
+#include <stdlib.h>  // for atol, atoi
+#include <time.h>    // for time
+
+#include <flint/flint.h>
+#include <flint/ulong_extras.h>
+#include <flint/profiler.h>
+#include <flint/nmod_poly.h>
+#include <flint/nmod_poly_mat.h>
+
+#include "pml.h"
+#include "nmod_mat_poly.h"
+#include "nmod_mat_poly_extra/impl.h"
+
+/* Straightforward entry-by-entry conversion: the reference that the blocked
+   implementation is checked against. */
+static void _set_trunc_from_poly_mat_naive(nmod_mat_poly_t matp,
+                                           const nmod_poly_mat_t pmat,
+                                           slong order)
+{
+    const slong len = nmod_poly_mat_max_length(pmat);
+    if (order > len)
+        order = len;
+
+    nmod_mat_poly_fit_length(matp, order);
+    _nmod_mat_poly_set_length(matp, order);
+
+    for (slong k = 0; k < order; k++)
+        for (slong i = 0; i < matp->r; i++)
+            for (slong j = 0; j < matp->c; j++)
+                nmod_mat_poly_entry(matp, k, i, j) = nmod_poly_get_coeff_ui(nmod_poly_mat_entry(pmat, i, j), k);
+
+    if (order < len)
+        _nmod_mat_poly_normalise(matp);
+}
+
+#define NFUNS 9
+
+static const char * description[NFUNS] = {
+    "#0  --> naive (entry by entry, local reference)      ",
+    "#1  --> blocked 8x8, scalar,          coeff-major    ",
+    "#2  --> blocked 8x8, scalar,          entry-major    ",
+    "#3  --> blocked 4x4, machine vectors, coeff-major    ",
+    "#4  --> blocked 4x4, machine vectors, entry-major    ",
+    "#5  --> blocked 8x8, AVX-512,         coeff-major    ",
+    "#6  --> blocked 8x8, AVX-512,         entry-major    ",
+    "#7  --> default kernel and schedule, no prefetch     ",
+    "#8  --> default kernel and schedule, prefetch        ",
+};
+
+/* (kernel, schedule, prefetch) of function number f >= 1; -1 means "default" */
+static const int fun_kern[NFUNS] = {0, NMOD_MAT_POLY_CONV_SCALAR, NMOD_MAT_POLY_CONV_SCALAR,
+                                       NMOD_MAT_POLY_CONV_VEC4, NMOD_MAT_POLY_CONV_VEC4,
+                                       NMOD_MAT_POLY_CONV_VEC8, NMOD_MAT_POLY_CONV_VEC8,
+                                       -1, -1};
+static const int fun_cmaj[NFUNS] = {0, 1, 0, 1, 0, 1, 0, -1, -1};
+static const int fun_pf[NFUNS]   = {0, -1, -1, -1, -1, -1, -1, 0, 1};
+
+/* random polynomial matrix; if ragged, entry lengths are spread below len */
+static void _rand_pmat(nmod_poly_mat_t pmat, flint_rand_t state, slong len, int ragged)
+{
+    nmod_poly_mat_rand(pmat, state, len);
+    if (ragged)
+        for (slong i = 0; i < nmod_poly_mat_nrows(pmat); i++)
+            for (slong j = 0; j < nmod_poly_mat_ncols(pmat); j++)
+                nmod_poly_truncate(nmod_poly_mat_entry(pmat, i, j),
+                                   1 + n_randint(state, len));
+    /* keep the announced order: force one entry to have full length */
+    nmod_poly_set_coeff_ui(nmod_poly_mat_entry(pmat, 0, 0), len - 1, UWORD(1));
+}
+
+static double time_fun(slong fun_nb, slong dim1, slong dim2, slong len,
+                       ulong modn, int ragged, flint_rand_t state)
+{
+    nmod_poly_mat_t pmat;
+    nmod_poly_mat_init(pmat, dim1, dim2, modn);
+    _rand_pmat(pmat, state, len, ragged);
+
+    nmod_mat_poly_t matp;
+    nmod_mat_poly_init(matp, dim1, dim2, modn);
+
+    double FLINT_SET_BUT_UNUSED(tcpu), twall;
+
+    if (fun_nb == 0)
+    {
+        TIMEIT_START;
+        _set_trunc_from_poly_mat_naive(matp, pmat, len);
+        TIMEIT_STOP_VALUES(tcpu, twall);
+    }
+    else
+    {
+        const int kern = fun_kern[fun_nb];
+        const int cmaj = fun_cmaj[fun_nb];
+        const int pf = fun_pf[fun_nb];
+        TIMEIT_START;
+        _nmod_mat_poly_set_trunc_from_poly_mat(matp, pmat, len, kern, cmaj, pf);
+        TIMEIT_STOP_VALUES(tcpu, twall);
+    }
+
+    nmod_mat_poly_clear(matp);
+    nmod_poly_mat_clear(pmat);
+
+    /* nanoseconds per converted word */
+    return 1e9 * twall / ((double) dim1 * (double) dim2 * (double) len);
+}
+
+int main(int argc, char ** argv)
+{
+    flint_rand_t state;
+    flint_rand_init(state);
+    flint_rand_set_seed(state, time(NULL), time(NULL) + 129384125L);
+
+    flint_printf("build: 4x4 machine-vectors kernel: %d, 8x8 AVX-512 kernel: %d\n",
+#if defined(PML_HAVE_AVX2)
+                 1,
+#else
+                 0,
+#endif
+#if defined(PML_HAVE_AVX512)
+                 1
+#else
+                 0
+#endif
+                );
+    flint_printf("(unavailable kernels silently fall back, columns then repeat)\n");
+
+    if (argc == 1)
+    {
+        flint_printf("Usage: `%s [nbits] [fun] [dim1] [dim2] [len] [opt:ragged]`\n", argv[0]);
+        flint_printf("   No argument runs a default grid with all functions.\n");
+        flint_printf("   - nbits: number of bits in (1..64] for the modulus, nextprime(2**(nbits-1))\n");
+        flint_printf("   - fun: id of the timed function, -1 for all (see below)\n");
+        flint_printf("   - dim1, dim2: the input matrix is dim1 x dim2\n");
+        flint_printf("   - len: the input has length len (order of the conversion)\n");
+        flint_printf("   - ragged: optional, if nonzero the entries get unequal lengths\n");
+        flint_printf("\nAvailable functions:\n");
+        for (slong j = 0; j < NFUNS; j++)
+            flint_printf("   %s\n", description[j]);
+        flint_printf("\nRunning default grid (ns per converted word, 60-bit modulus):\n");
+
+        const ulong modn = n_nextprime(UWORD(1) << 59, 0);
+        const slong dims[] = {2, 4, 8, 16, 32, 64, 128};
+        const slong lens[] = {8, 32, 128, 512, 2048};
+
+        flint_printf("%5s %6s %8s", "dim", "len", "MB");
+        for (slong j = 0; j < NFUNS; j++)
+            flint_printf(" %8s%-2wd", "fun#", j);
+        flint_printf("   speedup\n");
+
+        for (slong di = 0; di < 7; di++)
+            for (slong li = 0; li < 5; li++)
+            {
+                const slong d = dims[di], len = lens[li];
+                if ((double) d * d * len > 2.0e7)
+                    continue;
+                flint_printf("%5wd %6wd %8.2f", d, len, (double) d * d * len * 8 / 1048576.0);
+                double t[NFUNS], best = 1e30;
+                for (slong j = 0; j < NFUNS; j++)
+                {
+                    t[j] = time_fun(j, d, d, len, modn, 0, state);
+                    if (j > 0 && t[j] < best)
+                        best = t[j];
+                    flint_printf(" %10.3f", t[j]);
+                }
+                flint_printf("   %5.2fx\n", t[0] / best);
+                fflush(stdout);
+            }
+
+        flint_rand_clear(state);
+        return 0;
+    }
+
+    if (argc >= 6)
+    {
+        const slong b = atol(argv[1]);
+        const slong ifun = atol(argv[2]);
+        const slong dim1 = atol(argv[3]);
+        const slong dim2 = atol(argv[4]);
+        const slong len = atol(argv[5]);
+        const int ragged = (argc >= 7) ? atoi(argv[6]) : 0;
+
+        const ulong modn = n_nextprime(UWORD(1) << (b - 1), 0);
+
+        flint_printf("Available functions:\n");
+        for (slong j = 0; j < NFUNS; j++)
+            flint_printf("   %s\n", description[j]);
+
+        flint_printf("%-5s%-6s%-6s%-8s", "bits", "dim1", "dim2", "len");
+        if (ifun >= 0)
+            flint_printf("fun#%-6wd\n", ifun);
+        else
+        {
+            for (slong j = 0; j < NFUNS; j++)
+                flint_printf("fun#%-6wd", j);
+            flint_printf("\n");
+        }
+
+        flint_printf("%-5wd%-6wd%-6wd%-8wd", b, dim1, dim2, len);
+        if (ifun >= 0)
+            flint_printf("%-10.3f", time_fun(ifun, dim1, dim2, len, modn, ragged, state));
+        else
+            for (slong j = 0; j < NFUNS; j++)
+                flint_printf("%-10.3f", time_fun(j, dim1, dim2, len, modn, ragged, state));
+        flint_printf("\n");
+    }
+
+    flint_rand_clear(state);
+    return 0;
+}

--- a/flint-extras/src/nmod_mat_poly_extra/profile/p-set_from_poly_mat.c
+++ b/flint-extras/src/nmod_mat_poly_extra/profile/p-set_from_poly_mat.c
@@ -53,7 +53,7 @@ static void _set_trunc_from_poly_mat_naive(nmod_mat_poly_t matp,
         _nmod_mat_poly_normalise(matp);
 }
 
-#define NFUNS 9
+#define NFUNS 8
 
 static const char * description[NFUNS] = {
     "#0  --> naive (entry by entry, local reference)      ",
@@ -63,17 +63,15 @@ static const char * description[NFUNS] = {
     "#4  --> blocked 4x4, machine vectors, entry-major    ",
     "#5  --> blocked 8x8, AVX-512,         coeff-major    ",
     "#6  --> blocked 8x8, AVX-512,         entry-major    ",
-    "#7  --> default kernel and schedule, no prefetch     ",
-    "#8  --> default kernel and schedule, prefetch        ",
+    "#7  --> default kernel and schedule                  ",
 };
 
-/* (kernel, schedule, prefetch) of function number f >= 1; -1 means "default" */
+/* (kernel, schedule) of function number f >= 1; -1 means "default" */
 static const int fun_kern[NFUNS] = {0, NMOD_MAT_POLY_CONV_SCALAR, NMOD_MAT_POLY_CONV_SCALAR,
                                        NMOD_MAT_POLY_CONV_VEC4, NMOD_MAT_POLY_CONV_VEC4,
                                        NMOD_MAT_POLY_CONV_VEC8, NMOD_MAT_POLY_CONV_VEC8,
-                                       -1, -1};
-static const int fun_cmaj[NFUNS] = {0, 1, 0, 1, 0, 1, 0, -1, -1};
-static const int fun_pf[NFUNS]   = {0, -1, -1, -1, -1, -1, -1, 0, 1};
+                                       -1};
+static const int fun_cmaj[NFUNS] = {0, 1, 0, 1, 0, 1, 0, -1};
 
 /* random polynomial matrix; if ragged, entry lengths are spread below len */
 static void _rand_pmat(nmod_poly_mat_t pmat, flint_rand_t state, slong len, int ragged)
@@ -108,11 +106,9 @@ static double time_fun(slong fun_nb, slong dim1, slong dim2, slong len,
     }
     else
     {
-        const int kern = fun_kern[fun_nb];
-        const int cmaj = fun_cmaj[fun_nb];
-        const int pf = fun_pf[fun_nb];
         TIMEIT_START;
-        _nmod_mat_poly_set_trunc_from_poly_mat(matp, pmat, len, kern, cmaj, pf);
+        _nmod_mat_poly_set_trunc_from_poly_mat(matp, pmat, len,
+                                               fun_kern[fun_nb], fun_cmaj[fun_nb]);
         TIMEIT_STOP_VALUES(tcpu, twall);
     }
 
@@ -129,17 +125,19 @@ int main(int argc, char ** argv)
     flint_rand_init(state);
     flint_rand_set_seed(state, time(NULL), time(NULL) + 129384125L);
 
-    flint_printf("build: 4x4 machine-vectors kernel: %d, 8x8 AVX-512 kernel: %d\n",
-#if defined(PML_HAVE_AVX2)
+    flint_printf("build: 4x4 machine-vectors kernel: %d, 8x8 AVX-512 kernel: %d,"
+                 " default schedule: %s\n",
+#if PML_HAVE_MACHINE_VECTORS
                  1,
 #else
                  0,
 #endif
-#if defined(PML_HAVE_AVX512)
-                 1
+#if PML_HAVE_AVX512
+                 1,
 #else
-                 0
+                 0,
 #endif
+                 PML_CONV_COEFF_MAJOR ? "coeff-major" : "entry-major"
                 );
     flint_printf("(unavailable kernels silently fall back, columns then repeat)\n");
 

--- a/flint-extras/src/nmod_mat_poly_extra/test/main.c
+++ b/flint-extras/src/nmod_mat_poly_extra/test/main.c
@@ -15,6 +15,7 @@
 
 #include "t-mbasis_variants.c"
 #include "t-mem.c"
+#include "t-set_from_poly_mat.c"
 #include "t-mintbasis.c"
 
 
@@ -24,6 +25,7 @@ test_struct tests[] =
 {
     TEST_FUNCTION(nmod_mat_poly_mbasis_variants),
     TEST_FUNCTION(nmod_mat_poly_mem),
+    TEST_FUNCTION(nmod_mat_poly_set_from_poly_mat),
     TEST_FUNCTION(nmod_mat_poly_mintbasis),
 };
 

--- a/flint-extras/src/nmod_mat_poly_extra/test/t-set_from_poly_mat.c
+++ b/flint-extras/src/nmod_mat_poly_extra/test/t-set_from_poly_mat.c
@@ -120,16 +120,16 @@ static int core_test_set_from_poly_mat(const nmod_poly_mat_t pmat,
         ok = 0;
 
     for (int kern = -1; ok && kern <= NMOD_MAT_POLY_CONV_VEC8; kern++)
-        for (int cmaj = -1; ok && cmaj <= 1; cmaj++)
+        for (int dmaj = -1; ok && dmaj <= 1; dmaj++)
         {
             /* leave some stale data behind, of a length unrelated to order */
             nmod_mat_poly_rand(res, state, n_randint(state, 2 * order + 3));
 
-            _nmod_mat_poly_set_trunc_from_poly_mat(res, pmat, order, kern, cmaj);
+            _nmod_mat_poly_set_trunc_from_poly_mat(res, pmat, order, kern, dmaj);
 
             if (! _matp_equal(ref, res))
             {
-                flint_printf("failure with kern = %d, cmaj = %d\n", kern, cmaj);
+                flint_printf("failure with kern = %d, dmaj = %d\n", kern, dmaj);
                 ok = 0;
             }
         }

--- a/flint-extras/src/nmod_mat_poly_extra/test/t-set_from_poly_mat.c
+++ b/flint-extras/src/nmod_mat_poly_extra/test/t-set_from_poly_mat.c
@@ -1,0 +1,259 @@
+/*
+    Copyright (C) 2026 Vincent Neiger
+
+    This file is part of PML.
+
+    PML is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License version 2.0 (GPL-2.0-or-later)
+    as published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version. See
+    <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Tests the nmod_poly_mat -> nmod_mat_poly conversion.
+ *
+ * For each random instance, the blocked implementation is run with every
+ * option accepted by _nmod_mat_poly_set_trunc_from_poly_mat, plus the default
+ * option in nmod_mat_poly_set_trunc_from_poly_mat, and each result is compared
+ * with the straightforward conversion (*_naive below).
+ *
+ * Unavailable kernels fall back to an available one, so the loop below is
+ * portable; on a given build several columns may test the same code.
+ *
+ * The instances deliberately cover:
+ *   - dimensions and orders on both sides of the block sizes 4 and 8, and
+ *     the degenerate 0 x c, r x 0, order 0 cases;
+ *   - input entries of unequal lengths, including zero entries (so that the
+ *     zero-padding above each entry's length is exercised, both inside a
+ *     block and in the residual bands);
+ *   - a destination that already holds data, of larger and of smaller length
+ *     than the requested order, so that stale coefficients must be
+ *     overwritten;
+ *   - truncation orders below, at, and above the length of the input;
+ *   - a window of a polynomial matrix as input, whose row stride differs
+ *     from its number of columns;
+ *   - a destination whose own row stride is larger than its number of
+ *     columns, which takes the row-by-row path.
+ */
+
+#include <flint/test_helpers.h>
+#include <flint/nmod_poly.h>
+#include <flint/nmod_poly_mat.h>
+
+#include "nmod_mat_poly.h"
+#include "nmod_mat_poly_extra/impl.h"
+
+/* reference point for checks */
+static void _set_trunc_from_poly_mat_naive(nmod_mat_poly_t matp,
+                                           const nmod_poly_mat_t pmat,
+                                           slong order)
+{
+    const slong len = nmod_poly_mat_max_length(pmat);
+    if (order > len)
+        order = len;
+
+    nmod_mat_poly_fit_length(matp, order);
+    _nmod_mat_poly_set_length(matp, order);
+
+    for (slong k = 0; k < order; k++)
+        for (slong i = 0; i < matp->r; i++)
+            for (slong j = 0; j < matp->c; j++)
+                nmod_mat_poly_entry(matp, k, i, j) = nmod_poly_get_coeff_ui(nmod_poly_mat_entry(pmat, i, j), k);
+
+    if (order < len)
+        _nmod_mat_poly_normalise(matp);
+}
+
+/* full equality, including length */
+static int _matp_equal(const nmod_mat_poly_t a, const nmod_mat_poly_t b)
+{
+    nmod_mat_t ca, cb;
+    if (a->length != b->length || a->r != b->r || a->c != b->c)
+        return 0;
+    for (slong k = 0; k < a->length; k++)
+    {
+        nmod_mat_poly_coeff_attach(ca, a, k);
+        nmod_mat_poly_coeff_attach(cb, b, k);
+        if (! nmod_mat_equal(ca, cb))
+            return 0;
+    }
+    return 1;
+}
+
+/* also check against the definition, entry by entry */
+static int _matp_matches_pmat(const nmod_mat_poly_t matp,
+                              const nmod_poly_mat_t pmat,
+                              slong order)
+{
+    for (slong k = 0; k < matp->length; k++)
+        for (slong i = 0; i < matp->r; i++)
+            for (slong j = 0; j < matp->c; j++)
+                if (nmod_mat_poly_entry(matp, k, i, j)
+                        != nmod_poly_get_coeff_ui(nmod_poly_mat_entry(pmat, i, j), k))
+                    return 0;
+    /* nothing of degree >= length, up to the truncation order */
+    for (slong k = matp->length; k < order; k++)
+        for (slong i = 0; i < matp->r; i++)
+            for (slong j = 0; j < matp->c; j++)
+                if (nmod_poly_get_coeff_ui(nmod_poly_mat_entry(pmat, i, j), k) != UWORD(0))
+                    return 0;
+    return 1;
+}
+
+static int core_test_set_from_poly_mat(const nmod_poly_mat_t pmat,
+                                       slong order,
+                                       flint_rand_t state)
+{
+    const slong r = nmod_poly_mat_nrows(pmat);
+    const slong c = nmod_poly_mat_ncols(pmat);
+    const ulong prime = nmod_poly_mat_modulus(pmat);
+    int ok = 1;
+
+    nmod_mat_poly_t ref, res;
+    nmod_mat_poly_init(ref, r, c, prime);
+    nmod_mat_poly_init(res, r, c, prime);
+
+    _set_trunc_from_poly_mat_naive(ref, pmat, order);
+
+    if (! _matp_matches_pmat(ref, pmat, order))
+        ok = 0;
+
+    for (int kern = -1; ok && kern <= NMOD_MAT_POLY_CONV_VEC8; kern++)
+        for (int cmaj = -1; ok && cmaj <= 1; cmaj++)
+            for (int pf = -1; ok && pf <= 1; pf++)
+            {
+                /* leave some stale data behind, of a length unrelated to order */
+                nmod_mat_poly_rand(res, state, n_randint(state, 2 * order + 3));
+
+                _nmod_mat_poly_set_trunc_from_poly_mat(res, pmat, order, kern, cmaj, pf);
+
+                if (! _matp_equal(ref, res))
+                {
+                    flint_printf("failure with kern = %d, cmaj = %d, pf = %d\n",
+                                 kern, cmaj, pf);
+                    ok = 0;
+                }
+            }
+
+    /* the dispatcher, and the non-truncated entry point */
+    if (ok)
+    {
+        nmod_mat_poly_rand(res, state, n_randint(state, 2 * order + 3));
+        nmod_mat_poly_set_trunc_from_poly_mat(res, pmat, order);
+        ok = _matp_equal(ref, res);
+    }
+
+    if (ok && order >= nmod_poly_mat_max_length(pmat))
+    {
+        nmod_mat_poly_rand(res, state, n_randint(state, 2 * order + 3));
+        nmod_mat_poly_set_from_poly_mat(res, pmat);
+        ok = _matp_equal(ref, res);
+    }
+
+    /* same, with a destination whose row stride is not the number of columns:
+       this takes the row-by-row path of the implementation */
+    if (ok && r > 0 && c > 0)
+    {
+        nmod_mat_poly_t wide;
+        nmod_mat_poly_init(wide, r, c, prime);
+        wide->stride = c + 1 + n_randint(state, 8);
+        nmod_mat_poly_set_trunc_from_poly_mat(wide, pmat, order);
+        for (slong k = 0; ok && k < wide->length; k++)
+            for (slong i = 0; ok && i < r; i++)
+                for (slong j = 0; ok && j < c; j++)
+                    if (nmod_mat_poly_entry(wide, k, i, j) != nmod_mat_poly_entry(ref, k, i, j))
+                        ok = 0;
+        if (ok && wide->length != ref->length)
+            ok = 0;
+        nmod_mat_poly_clear(wide);
+    }
+
+    nmod_mat_poly_clear(ref);
+    nmod_mat_poly_clear(res);
+    return ok;
+}
+
+TEST_FUNCTION_START(nmod_mat_poly_set_from_poly_mat, state)
+{
+    int result;
+
+    for (slong iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        const slong nbits = 2 + n_randint(state, 63);
+        const ulong prime = n_randprime(state, nbits, 1);
+
+        /* dimensions and lengths straddling the block sizes 4 and 8 */
+        const slong rdim = n_randint(state, 12);
+        const slong cdim = n_randint(state, 12);
+        const slong len = n_randint(state, 26);
+
+        nmod_poly_mat_t pmat;
+        nmod_poly_mat_init(pmat, rdim, cdim, prime);
+
+        /* entries of unequal lengths, some of them zero */
+        for (slong i = 0; i < rdim; i++)
+            for (slong j = 0; j < cdim; j++)
+            {
+                if (n_randint(state, 6) == 0)
+                    nmod_poly_zero(nmod_poly_mat_entry(pmat, i, j));
+                else
+                    nmod_poly_randtest(nmod_poly_mat_entry(pmat, i, j), state,
+                                       1 + n_randint(state, len + 1));
+            }
+
+        /* order below, at, and above the length of the input */
+        const slong maxlen = nmod_poly_mat_max_length(pmat);
+        const slong order = n_randint(state, maxlen + 3);
+
+        result = core_test_set_from_poly_mat(pmat, order, state);
+
+        if (result && rdim > 1 && cdim > 1)
+        {
+            /* a window: its row stride differs from its column count */
+            nmod_poly_mat_t win;
+            nmod_poly_mat_window_init(win, pmat, 0, 0, rdim - 1, cdim - 1);
+            result = core_test_set_from_poly_mat(win, order, state);
+            nmod_poly_mat_window_clear(win);
+        }
+
+        if (!result)
+            TEST_FUNCTION_FAIL("prime = %wu, rdim = %wd, cdim = %wd, len = %wd, order = %wd\n",
+                               prime, rdim, cdim, len, order);
+
+        nmod_poly_mat_clear(pmat);
+    }
+
+    /* larger instances, to reach the blocked path with both schedules and
+       with the prefetching on */
+    {
+        const ulong prime = UWORD(1099511627791);
+        const slong shapes[4][2] = {{9, 9}, {5, 40}, {40, 5}, {16, 16}};
+        const slong orders[3] = {7, 33, 130};
+
+        for (int s = 0; s < 4; s++)
+            for (int o = 0; o < 3; o++)
+            {
+                nmod_poly_mat_t pmat;
+                nmod_poly_mat_init(pmat, shapes[s][0], shapes[s][1], prime);
+                nmod_poly_mat_rand(pmat, state, orders[o]);
+                /* make a few entries shorter, including in the last block */
+                for (slong i = 0; i < shapes[s][0]; i++)
+                    for (slong j = 0; j < shapes[s][1]; j++)
+                        if ((i + j) % 5 == 0)
+                            nmod_poly_truncate(nmod_poly_mat_entry(pmat, i, j),
+                                               n_randint(state, orders[o] + 1));
+
+                result = core_test_set_from_poly_mat(pmat, orders[o], state)
+                      && core_test_set_from_poly_mat(pmat, orders[o] / 2, state);
+
+                if (!result)
+                    TEST_FUNCTION_FAIL("large instance %wd x %wd, order %wd\n",
+                                       shapes[s][0], shapes[s][1], orders[o]);
+
+                nmod_poly_mat_clear(pmat);
+            }
+    }
+
+    TEST_FUNCTION_END(state);
+}

--- a/flint-extras/src/nmod_mat_poly_extra/test/t-set_from_poly_mat.c
+++ b/flint-extras/src/nmod_mat_poly_extra/test/t-set_from_poly_mat.c
@@ -121,20 +121,18 @@ static int core_test_set_from_poly_mat(const nmod_poly_mat_t pmat,
 
     for (int kern = -1; ok && kern <= NMOD_MAT_POLY_CONV_VEC8; kern++)
         for (int cmaj = -1; ok && cmaj <= 1; cmaj++)
-            for (int pf = -1; ok && pf <= 1; pf++)
+        {
+            /* leave some stale data behind, of a length unrelated to order */
+            nmod_mat_poly_rand(res, state, n_randint(state, 2 * order + 3));
+
+            _nmod_mat_poly_set_trunc_from_poly_mat(res, pmat, order, kern, cmaj);
+
+            if (! _matp_equal(ref, res))
             {
-                /* leave some stale data behind, of a length unrelated to order */
-                nmod_mat_poly_rand(res, state, n_randint(state, 2 * order + 3));
-
-                _nmod_mat_poly_set_trunc_from_poly_mat(res, pmat, order, kern, cmaj, pf);
-
-                if (! _matp_equal(ref, res))
-                {
-                    flint_printf("failure with kern = %d, cmaj = %d, pf = %d\n",
-                                 kern, cmaj, pf);
-                    ok = 0;
-                }
+                flint_printf("failure with kern = %d, cmaj = %d\n", kern, cmaj);
+                ok = 0;
             }
+        }
 
     /* the dispatcher, and the non-truncated entry point */
     if (ok)
@@ -224,8 +222,7 @@ TEST_FUNCTION_START(nmod_mat_poly_set_from_poly_mat, state)
         nmod_poly_mat_clear(pmat);
     }
 
-    /* larger instances, to reach the blocked path with both schedules and
-       with the prefetching on */
+    /* larger instances, to reach the blocked path with both schedules */
     {
         const ulong prime = UWORD(1099511627791);
         const slong shapes[4][2] = {{9, 9}, {5, 40}, {40, 5}, {16, 16}};

--- a/flint-extras/src/nmod_poly_mat_extra/impl.h
+++ b/flint-extras/src/nmod_poly_mat_extra/impl.h
@@ -16,6 +16,8 @@
 #include <flint/nmod_types.h>
 #include <flint/nmod_poly.h>  /* for geometric_progression_t */
 
+#include "nmod_mat_poly.h"     /* for nmod_mat_poly_t */
+
 /* Hermite form helpers */
 void _atomic_solve_pivot_collision_uechelon_rowwise(nmod_poly_mat_t mat, nmod_poly_mat_t other,
                                                     slong pi1, slong pi2, slong j);
@@ -36,6 +38,25 @@ void _reduce_against_pivot_general_rowwise(nmod_poly_mat_t mat, nmod_poly_mat_t 
                                    slong i, slong j, slong ii,
                                    nmod_poly_t u, nmod_poly_t v);
 ulong _normalize_pivot_general_rowwise(nmod_poly_mat_t mat, nmod_poly_mat_t other, slong i, slong j);
+
+/* Same as nmod_poly_mat_set_trunc_from_mat_poly, with explicit control over
+ * the block kernel and the loop schedule of the underlying transposition.
+ *
+ * `kern` is one of NMOD_MAT_POLY_CONV_{SCALAR,VEC4,VEC8} (see
+ * nmod_mat_poly_extra/impl.h); any other value selects the default, narrowed
+ * if its block does not fit inside the problem.
+ *
+ * `dmaj` is 1 for the entry-major schedule (the stores into the output
+ * polynomials are long sequential streams) and 0 for the coefficient-major
+ * one (the loads from the input matrices are long sequential streams); any
+ * other value (e.g. -1) selects the default.  Note that the two schedules
+ * carry the opposite names in the other direction: `dmaj` always means
+ * "sweep the destination rows sequentially". */
+void _nmod_poly_mat_set_trunc_from_mat_poly(nmod_poly_mat_t pmat,
+                                            const nmod_mat_poly_t matp,
+                                            slong order,
+                                            int kern,
+                                            int dmaj);
 
 /* multiplication helpers */
 void _nmod_poly_mat_mulmid_geometric1_precomp(nmod_poly_mat_t res,

--- a/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_utils.c
+++ b/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_utils.c
@@ -14,6 +14,8 @@
 #include <flint/nmod_poly.h>
 #include "nmod_poly_mat_utils.h"
 #include "nmod_mat_poly.h"
+#include "nmod_mat_poly_extra/impl.h"   /* _pml_transpose */
+#include "nmod_poly_mat_extra/impl.h"
 
 /**********************************************************************
 *                    ROW ROTATION DOWNWARD/UPWARD                    *
@@ -182,29 +184,131 @@ void _nmod_poly_mat_permute_columns_by_sorting_vec(nmod_poly_mat_t mat,
 /*------------------------------------------------------------*/
 /*------------------------------------------------------------*/
 
-void nmod_poly_mat_set_trunc_from_mat_poly(nmod_poly_mat_t pmat,
-                                           const nmod_mat_poly_t matp,
-                                           slong order)
+/* This is the transposition of the conversion in the other direction, so it
+   runs on the same blocked kernels; see nmod_mat_poly_extra/impl.h.  The two
+   sides are exchanged, and with them their alignments: here the source rows
+   (the coefficients of `matp`) are the 64-byte aligned ones and the
+   destination rows (the coefficient arrays of the entries of `pmat`) are
+   whatever `flint_realloc` returned, which is why this direction does not
+   pick the same default kernel as the other one. */
+
+/* Below this many words the pointer tables and their allocation dominate;
+   just run the naive loop. */
+#define _PML_SETFROM_TINY 512
+
+/* Default kernel.  Not the widest one, unlike the other direction: the
+   destination rows here are the coefficient arrays of nmod_poly entries, 16
+   byte aligned at best, so every 64-byte store straddles two cache lines
+   whereas a 32-byte one does so only half the time.  Measured over matrices
+   4x4 to 128x128 and lengths 32 to 8192, the 4-wide kernel and the widest
+   available one are within 2% of each other while the data fits in cache,
+   and the 4-wide one is 10% ahead once it does not. */
+#ifndef PML_SETFROM_MAT_POLY_KERNEL
+# define PML_SETFROM_MAT_POLY_KERNEL NMOD_MAT_POLY_CONV_VEC4
+#endif
+
+/* Default schedule: always sweep the destination rows, that is, write each
+   output polynomial from its constant coefficient upwards.  This direction
+   does not need the target test that PML_CONV_DST_MAJOR makes for the other
+   one, and for the same reason: what one wants is the *aligned* side of the
+   transposition to be the scattered one.  Here that side is the source (the
+   coefficients of the nmod_mat_poly, 64-byte aligned), so scattering the
+   loads and sweeping the stores is right everywhere -- and on Apple silicon
+   it is what the 128-byte cache line asks for anyway.  Measured on Zen 4 the
+   other schedule is 20% to 80% slower over the same grid. */
+#ifndef PML_SETFROM_MAT_POLY_DST_MAJOR
+# define PML_SETFROM_MAT_POLY_DST_MAJOR 1
+#endif
+
+void _nmod_poly_mat_set_trunc_from_mat_poly(nmod_poly_mat_t pmat,
+                                            const nmod_mat_poly_t matp,
+                                            slong order,
+                                            int kern,
+                                            int dmaj)
 {
     if (order > matp->length)
         order = matp->length;
 
+    const slong r = pmat->r;
+    const slong c = pmat->c;
+
     // prepare memory
-    for (slong i = 0; i < pmat->r; i++)
-        for (slong j = 0; j < pmat->c; j++)
+    for (slong i = 0; i < r; i++)
+        for (slong j = 0; j < c; j++)
             nmod_poly_fit_length(nmod_poly_mat_entry(pmat, i, j), order);
 
-    // fill data
-    for (slong k = 0; k < order; k++)
-        for (slong i = 0; i < pmat->r; i++)
-            for (slong j = 0; j < pmat->c; j++)
-                nmod_poly_mat_entry(pmat, i, j)->coeffs[k] = nmod_mat_poly_entry(matp, k, i, j);
+    if (order == 0 || r == 0 || c == 0)
+    {
+        for (slong i = 0; i < r; i++)
+            for (slong j = 0; j < c; j++)
+                _nmod_poly_set_length(nmod_poly_mat_entry(pmat, i, j), 0);
+        return;
+    }
+
+    if ((double) r * (double) c * (double) order < (double) _PML_SETFROM_TINY)
+    {
+        for (slong k = 0; k < order; k++)
+            for (slong i = 0; i < r; i++)
+                for (slong j = 0; j < c; j++)
+                    nmod_poly_mat_entry(pmat, i, j)->coeffs[k] = nmod_mat_poly_entry(matp, k, i, j);
+    }
+    else
+    {
+        /* Effective number of rows of the destination: the whole matrix when
+           the coefficients of `matp` are contiguous, one matrix row otherwise. */
+        const slong ndst = (matp->stride == c) ? r * c : c;
+
+        if (kern < 0 || kern > NMOD_MAT_POLY_CONV_VEC8)
+            kern = PML_SETFROM_MAT_POLY_KERNEL;
+        kern = _pml_transpose_narrow_kernel(kern, ndst, order);
+
+        if (dmaj < 0 || dmaj > 1)
+            dmaj = PML_SETFROM_MAT_POLY_DST_MAJOR;
+
+        nn_ptr * dst = (nn_ptr *) flint_malloc(r * c * sizeof(nn_ptr));
+        nn_srcptr * src = (nn_srcptr *) flint_malloc(order * sizeof(nn_srcptr));
+        slong * slen = (slong *) flint_malloc(order * sizeof(slong));
+
+        for (slong i = 0; i < r; i++)
+            for (slong j = 0; j < c; j++)
+                dst[i * c + j] = nmod_poly_mat_entry(pmat, i, j)->coeffs;
+
+        /* every source row is full: the coefficients of `matp` hold all the
+           entries of a matrix, with no truncation */
+        for (slong k = 0; k < order; k++)
+            slen[k] = ndst;
+
+        if (ndst == r * c)
+        {
+            for (slong k = 0; k < order; k++)
+                src[k] = matp->coeffs[k];
+            _pml_transpose(dst, r * c, src, slen, order, kern, dmaj);
+        }
+        else
+            for (slong i = 0; i < r; i++)
+            {
+                for (slong k = 0; k < order; k++)
+                    src[k] = matp->coeffs[k] + i * matp->stride;
+                _pml_transpose(dst + i * c, c, src, slen, order, kern, dmaj);
+            }
+
+        flint_free(dst);
+        flint_free(src);
+        flint_free(slen);
+    }
 
     // normalize
-    for (slong i = 0; i < pmat->r; i++)
-        for (slong j = 0; j < pmat->c; j++)
+    for (slong i = 0; i < r; i++)
+        for (slong j = 0; j < c; j++)
         {
             _nmod_poly_set_length(nmod_poly_mat_entry(pmat, i, j), order);
             _nmod_poly_normalise(nmod_poly_mat_entry(pmat, i, j));
         }
+}
+
+void nmod_poly_mat_set_trunc_from_mat_poly(nmod_poly_mat_t pmat,
+                                           const nmod_mat_poly_t matp,
+                                           slong order)
+{
+    _nmod_poly_mat_set_trunc_from_mat_poly(pmat, matp, order, -1, -1);
 }

--- a/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_utils.c
+++ b/flint-extras/src/nmod_poly_mat_extra/nmod_poly_mat_utils.c
@@ -196,15 +196,22 @@ void _nmod_poly_mat_permute_columns_by_sorting_vec(nmod_poly_mat_t mat,
    just run the naive loop. */
 #define _PML_SETFROM_TINY 512
 
-/* Default kernel.  Not the widest one, unlike the other direction: the
-   destination rows here are the coefficient arrays of nmod_poly entries, 16
-   byte aligned at best, so every 64-byte store straddles two cache lines
-   whereas a 32-byte one does so only half the time.  Measured over matrices
-   4x4 to 128x128 and lengths 32 to 8192, the 4-wide kernel and the widest
-   available one are within 2% of each other while the data fits in cache,
-   and the 4-wide one is 10% ahead once it does not. */
-#ifndef PML_SETFROM_MAT_POLY_KERNEL
-# define PML_SETFROM_MAT_POLY_KERNEL NMOD_MAT_POLY_CONV_VEC4
+/* Default kernel: the widest one available while the data is small, the
+   4-wide one above that.
+
+   The destination rows here are the coefficient arrays of nmod_poly entries,
+   16-byte aligned at best, so a 64-byte store straddles two cache lines every
+   single time whereas a 32-byte one does so only half the time.  While the
+   working set is in cache both halves of such a store are there too and the
+   split costs next to nothing, so the wider kernel wins on its lower
+   instruction count; once the data no longer fits, those split stores compete
+   for the same store buffers and line fills as the misses, and the narrower
+   kernel wins.
+
+   Set the threshold to 0 to always use the 4-wide kernel, or to SIZE_MAX to
+   always use the widest one.  It is flat between about 256 KB and 4 MB. */
+#ifndef PML_SETFROM_MAT_POLY_WIDE_BYTES
+# define PML_SETFROM_MAT_POLY_WIDE_BYTES (1024 * 1024)
 #endif
 
 /* Default schedule: always sweep the destination rows, that is, write each
@@ -259,7 +266,10 @@ void _nmod_poly_mat_set_trunc_from_mat_poly(nmod_poly_mat_t pmat,
         const slong ndst = (matp->stride == c) ? r * c : c;
 
         if (kern < 0 || kern > NMOD_MAT_POLY_CONV_VEC8)
-            kern = PML_SETFROM_MAT_POLY_KERNEL;
+            kern = ((double) r * (double) c * (double) order * sizeof(ulong)
+                        <= (double) PML_SETFROM_MAT_POLY_WIDE_BYTES)
+                 ? _pml_transpose_widest_kernel()
+                 : NMOD_MAT_POLY_CONV_VEC4;
         kern = _pml_transpose_narrow_kernel(kern, ndst, order);
 
         if (dmaj < 0 || dmaj > 1)

--- a/flint-extras/src/nmod_poly_mat_extra/profile/p-set_from_mat_poly.c
+++ b/flint-extras/src/nmod_poly_mat_extra/profile/p-set_from_mat_poly.c
@@ -10,13 +10,18 @@
     <https://www.gnu.org/licenses/>.
 */
 
-/* Timings for the nmod_poly_mat -> nmod_mat_poly conversion.
+/* Timings for the nmod_mat_poly -> nmod_poly_mat conversion.
  *
  * Unit: nanoseconds per converted word
  *
  * The conversion is a transposition of r*c*order words and moves 8 bytes in
  * and 8 bytes out per word, so a value close to the cost of a plain memcpy of
- * the same volume is the target. */
+ * the same volume is the target.
+ *
+ * Unlike the other direction, the destination rows here are the coefficient
+ * arrays of the entries of an nmod_poly_mat, whose alignment is whatever
+ * `flint_realloc` returned; the source rows, the coefficients of the
+ * nmod_mat_poly, are the 64-byte aligned ones. */
 
 #include <stdlib.h>  // for atol, atoi
 #include <time.h>    // for time
@@ -29,91 +34,98 @@
 
 #include "pml.h"
 #include "nmod_mat_poly.h"
+#include "nmod_poly_mat_utils.h"
 #include "nmod_mat_poly_extra/impl.h"
+#include "nmod_poly_mat_extra/impl.h"
 
 /* Straightforward entry-by-entry conversion: the reference that the blocked
    implementation is checked against. */
-static void _set_trunc_from_poly_mat_naive(nmod_mat_poly_t matp,
-                                           const nmod_poly_mat_t pmat,
+static void _set_trunc_from_mat_poly_naive(nmod_poly_mat_t pmat,
+                                           const nmod_mat_poly_t matp,
                                            slong order)
 {
-    const slong len = nmod_poly_mat_max_length(pmat);
-    if (order > len)
-        order = len;
+    if (order > matp->length)
+        order = matp->length;
 
-    nmod_mat_poly_fit_length(matp, order);
-    _nmod_mat_poly_set_length(matp, order);
+    for (slong i = 0; i < pmat->r; i++)
+        for (slong j = 0; j < pmat->c; j++)
+            nmod_poly_fit_length(nmod_poly_mat_entry(pmat, i, j), order);
 
     for (slong k = 0; k < order; k++)
-        for (slong i = 0; i < matp->r; i++)
-            for (slong j = 0; j < matp->c; j++)
-                nmod_mat_poly_entry(matp, k, i, j) = nmod_poly_get_coeff_ui(nmod_poly_mat_entry(pmat, i, j), k);
+        for (slong i = 0; i < pmat->r; i++)
+            for (slong j = 0; j < pmat->c; j++)
+                nmod_poly_mat_entry(pmat, i, j)->coeffs[k] = nmod_mat_poly_entry(matp, k, i, j);
 
-    if (order < len)
-        _nmod_mat_poly_normalise(matp);
+    for (slong i = 0; i < pmat->r; i++)
+        for (slong j = 0; j < pmat->c; j++)
+        {
+            _nmod_poly_set_length(nmod_poly_mat_entry(pmat, i, j), order);
+            _nmod_poly_normalise(nmod_poly_mat_entry(pmat, i, j));
+        }
 }
 
 #define NFUNS 8
 
 static const char * description[NFUNS] = {
-    "#0  --> naive (entry by entry, local reference)      ",
-    "#1  --> blocked 8x8, scalar,          coeff-major    ",
-    "#2  --> blocked 8x8, scalar,          entry-major    ",
-    "#3  --> blocked 4x4, machine vectors, coeff-major    ",
-    "#4  --> blocked 4x4, machine vectors, entry-major    ",
-    "#5  --> blocked 8x8, AVX-512,         coeff-major    ",
-    "#6  --> blocked 8x8, AVX-512,         entry-major    ",
-    "#7  --> default kernel and schedule                  ",
+    "#0  --> naive (entry by entry, local reference)           ",
+    "#1  --> blocked 8x8, scalar,          entry-major (st seq)",
+    "#2  --> blocked 8x8, scalar,          coeff-major (ld seq)",
+    "#3  --> blocked 4x4, machine vectors, entry-major (st seq)",
+    "#4  --> blocked 4x4, machine vectors, coeff-major (ld seq)",
+    "#5  --> blocked 8x8, AVX-512,         entry-major (st seq)",
+    "#6  --> blocked 8x8, AVX-512,         coeff-major (ld seq)",
+    "#7  --> default kernel and schedule                       ",
 };
 
-/* (kernel, schedule) of function number f >= 1; -1 means "default" */
+/* (kernel, schedule) of function number f >= 1; -1 means "default".
+   `dmaj == 1` sweeps the destination rows, i.e. the output polynomials. */
 static const int fun_kern[NFUNS] = {0, NMOD_MAT_POLY_CONV_SCALAR, NMOD_MAT_POLY_CONV_SCALAR,
                                        NMOD_MAT_POLY_CONV_VEC4, NMOD_MAT_POLY_CONV_VEC4,
                                        NMOD_MAT_POLY_CONV_VEC8, NMOD_MAT_POLY_CONV_VEC8,
                                        -1};
 static const int fun_dmaj[NFUNS] = {0, 1, 0, 1, 0, 1, 0, -1};
 
-/* random polynomial matrix; if ragged, entry lengths are spread below len */
-static void _rand_pmat(nmod_poly_mat_t pmat, flint_rand_t state, slong len, int ragged)
+/* random matrix polynomial; if `ragged`, some coefficients are zeroed, so the
+   output entries come out with unequal lengths */
+static void _rand_matp(nmod_mat_poly_t matp, flint_rand_t state, slong len, int ragged)
 {
-    nmod_poly_mat_rand(pmat, state, len);
+    nmod_mat_poly_rand(matp, state, len);
     if (ragged)
-        for (slong i = 0; i < nmod_poly_mat_nrows(pmat); i++)
-            for (slong j = 0; j < nmod_poly_mat_ncols(pmat); j++)
-                nmod_poly_truncate(nmod_poly_mat_entry(pmat, i, j),
-                                   1 + n_randint(state, len));
-    /* keep the announced order: force one entry to have full length */
-    nmod_poly_set_coeff_ui(nmod_poly_mat_entry(pmat, 0, 0), len - 1, UWORD(1));
+        for (slong k = 0; k < matp->length; k++)
+            for (slong i = 0; i < matp->r; i++)
+                for (slong j = 0; j < matp->c; j++)
+                    if (n_randint(state, 3) == 0)
+                        nmod_mat_poly_entry(matp, k, i, j) = UWORD(0);
 }
 
 static double time_fun(slong fun_nb, slong dim1, slong dim2, slong len,
                        ulong modn, int ragged, flint_rand_t state)
 {
-    nmod_poly_mat_t pmat;
-    nmod_poly_mat_init(pmat, dim1, dim2, modn);
-    _rand_pmat(pmat, state, len, ragged);
-
     nmod_mat_poly_t matp;
     nmod_mat_poly_init(matp, dim1, dim2, modn);
+    _rand_matp(matp, state, len, ragged);
+
+    nmod_poly_mat_t pmat;
+    nmod_poly_mat_init(pmat, dim1, dim2, modn);
 
     double FLINT_SET_BUT_UNUSED(tcpu), twall;
 
     if (fun_nb == 0)
     {
         TIMEIT_START;
-        _set_trunc_from_poly_mat_naive(matp, pmat, len);
+        _set_trunc_from_mat_poly_naive(pmat, matp, len);
         TIMEIT_STOP_VALUES(tcpu, twall);
     }
     else
     {
         TIMEIT_START;
-        _nmod_mat_poly_set_trunc_from_poly_mat(matp, pmat, len,
+        _nmod_poly_mat_set_trunc_from_mat_poly(pmat, matp, len,
                                                fun_kern[fun_nb], fun_dmaj[fun_nb]);
         TIMEIT_STOP_VALUES(tcpu, twall);
     }
 
-    nmod_mat_poly_clear(matp);
     nmod_poly_mat_clear(pmat);
+    nmod_mat_poly_clear(matp);
 
     /* nanoseconds per converted word */
     return 1e9 * twall / ((double) dim1 * (double) dim2 * (double) len);
@@ -137,7 +149,7 @@ int main(int argc, char ** argv)
 #else
                  0,
 #endif
-                 PML_CONV_DST_MAJOR ? "coeff-major" : "entry-major"
+                 PML_CONV_DST_MAJOR ? "entry-major" : "coeff-major"
                 );
     flint_printf("(unavailable kernels silently fall back, columns then repeat)\n");
 
@@ -147,9 +159,9 @@ int main(int argc, char ** argv)
         flint_printf("   No argument runs a default grid with all functions.\n");
         flint_printf("   - nbits: number of bits in (1..64] for the modulus, nextprime(2**(nbits-1))\n");
         flint_printf("   - fun: id of the timed function, -1 for all (see below)\n");
-        flint_printf("   - dim1, dim2: the input matrix is dim1 x dim2\n");
+        flint_printf("   - dim1, dim2: the input matrix polynomial is dim1 x dim2\n");
         flint_printf("   - len: the input has length len (order of the conversion)\n");
-        flint_printf("   - ragged: optional, if nonzero the entries get unequal lengths\n");
+        flint_printf("   - ragged: optional, if nonzero some input coefficients are zeroed\n");
         flint_printf("\nAvailable functions:\n");
         for (slong j = 0; j < NFUNS; j++)
             flint_printf("   %s\n", description[j]);

--- a/flint-extras/src/nmod_poly_mat_extra/test/main.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/main.c
@@ -23,6 +23,7 @@
 #include "t-mul_vandermonde.c"
 #include "t-mul_waksman.c"
 #include "t-mulmid.c"
+#include "t-set_from_mat_poly.c"
 #include "t-mbasis.c"
 #include "t-pmbasis.c"
 #include "t-pmintbasis.c"
@@ -46,6 +47,7 @@ test_struct tests[] =
     TEST_FUNCTION(nmod_poly_mat_mul_waksman),
     TEST_FUNCTION(nmod_poly_mat_mul_vandermonde),
     TEST_FUNCTION(nmod_poly_mat_mulmid),
+    TEST_FUNCTION(nmod_poly_mat_set_from_mat_poly),
     TEST_FUNCTION(nmod_poly_mat_pmbasis),
     TEST_FUNCTION(nmod_poly_mat_pmintbasis),
     TEST_FUNCTION(nmod_poly_mat_pmintbasis_nondistinct),

--- a/flint-extras/src/nmod_poly_mat_extra/test/t-set_from_mat_poly.c
+++ b/flint-extras/src/nmod_poly_mat_extra/test/t-set_from_mat_poly.c
@@ -1,0 +1,272 @@
+/*
+    Copyright (C) 2026 Vincent Neiger
+
+    This file is part of PML.
+
+    PML is free software: you can redistribute it and/or modify it under
+    the terms of the GNU General Public License version 2.0 (GPL-2.0-or-later)
+    as published by the Free Software Foundation; either version 2 of the
+    License, or (at your option) any later version. See
+    <https://www.gnu.org/licenses/>.
+*/
+
+/**
+ * Tests the nmod_mat_poly -> nmod_poly_mat conversion.
+ *
+ * For each random instance, the blocked implementation is run with every
+ * option accepted by _nmod_poly_mat_set_trunc_from_mat_poly, plus the default
+ * options in nmod_poly_mat_set_trunc_from_mat_poly and
+ * nmod_poly_mat_set_from_mat_poly, and each result is compared with the
+ * straightforward conversion (*_naive below).
+ *
+ * Unavailable kernels fall back to an available one, so the loop below is
+ * portable; on a given build several of its iterations test the same code.
+ *
+ * The instances deliberately cover:
+ *   - dimensions and orders on both sides of the block sizes 4 and 8, and the
+ *     degenerate 0 x c, r x 0, order 0 and length 0 cases;
+ *   - inputs whose trailing coefficients are zero, entirely or in part, so
+ *     that the output entries come out with unequal lengths and the
+ *     normalisation is exercised;
+ *   - a destination that already holds data, of larger and of smaller length
+ *     than the requested order, so that stale coefficients must be overwritten
+ *     and stale lengths corrected;
+ *   - truncation orders below, at, and above the length of the input;
+ *   - an input whose row stride is larger than its number of columns, which
+ *     takes the row-by-row path of the implementation;
+ *   - a window of a polynomial matrix as destination, whose row stride
+ *     differs from its number of columns.
+ */
+
+#include <flint/test_helpers.h>
+#include <flint/nmod_poly.h>
+#include <flint/nmod_poly_mat.h>
+
+#include "nmod_mat_poly.h"
+#include "nmod_poly_mat_utils.h"
+#include "nmod_mat_poly_extra/impl.h"
+#include "nmod_poly_mat_extra/impl.h"
+
+/* reference point for checks */
+static void _set_trunc_from_mat_poly_naive(nmod_poly_mat_t pmat,
+                                           const nmod_mat_poly_t matp,
+                                           slong order)
+{
+    if (order > matp->length)
+        order = matp->length;
+
+    for (slong i = 0; i < pmat->r; i++)
+        for (slong j = 0; j < pmat->c; j++)
+            nmod_poly_fit_length(nmod_poly_mat_entry(pmat, i, j), order);
+
+    for (slong k = 0; k < order; k++)
+        for (slong i = 0; i < pmat->r; i++)
+            for (slong j = 0; j < pmat->c; j++)
+                nmod_poly_mat_entry(pmat, i, j)->coeffs[k] = nmod_mat_poly_entry(matp, k, i, j);
+
+    for (slong i = 0; i < pmat->r; i++)
+        for (slong j = 0; j < pmat->c; j++)
+        {
+            _nmod_poly_set_length(nmod_poly_mat_entry(pmat, i, j), order);
+            _nmod_poly_normalise(nmod_poly_mat_entry(pmat, i, j));
+        }
+}
+
+/* full equality, including the length of every entry */
+static int _pmat_equal(const nmod_poly_mat_t a, const nmod_poly_mat_t b)
+{
+    if (a->r != b->r || a->c != b->c)
+        return 0;
+    for (slong i = 0; i < a->r; i++)
+        for (slong j = 0; j < a->c; j++)
+        {
+            const nmod_poly_struct * pa = nmod_poly_mat_entry(a, i, j);
+            const nmod_poly_struct * pb = nmod_poly_mat_entry(b, i, j);
+            if (pa->length != pb->length || ! nmod_poly_equal(pa, pb))
+                return 0;
+        }
+    return 1;
+}
+
+/* also check against the definition, entry by entry */
+static int _pmat_matches_matp(const nmod_poly_mat_t pmat,
+                              const nmod_mat_poly_t matp,
+                              slong order)
+{
+    if (order > matp->length)
+        order = matp->length;
+
+    for (slong i = 0; i < pmat->r; i++)
+        for (slong j = 0; j < pmat->c; j++)
+        {
+            const nmod_poly_struct * p = nmod_poly_mat_entry(pmat, i, j);
+            if (p->length > order)
+                return 0;
+            for (slong k = 0; k < order; k++)
+                if (nmod_poly_get_coeff_ui(p, k) != nmod_mat_poly_entry(matp, k, i, j))
+                    return 0;
+        }
+    return 1;
+}
+
+/* fill a destination with stale data of a length unrelated to `order` */
+static void _stale(nmod_poly_mat_t pmat, slong order, flint_rand_t state)
+{
+    for (slong i = 0; i < pmat->r; i++)
+        for (slong j = 0; j < pmat->c; j++)
+            nmod_poly_randtest(nmod_poly_mat_entry(pmat, i, j), state,
+                               n_randint(state, 2 * order + 4));
+}
+
+static int core_test_set_from_mat_poly(const nmod_mat_poly_t matp,
+                                       slong order,
+                                       flint_rand_t state)
+{
+    const slong r = matp->r;
+    const slong c = matp->c;
+    const ulong prime = matp->mod.n;
+    int ok = 1;
+
+    nmod_poly_mat_t ref, res;
+    nmod_poly_mat_init(ref, r, c, prime);
+    nmod_poly_mat_init(res, r, c, prime);
+
+    _stale(ref, order, state);
+    _set_trunc_from_mat_poly_naive(ref, matp, order);
+
+    if (! _pmat_matches_matp(ref, matp, order))
+        ok = 0;
+
+    for (int kern = -1; ok && kern <= NMOD_MAT_POLY_CONV_VEC8; kern++)
+        for (int dmaj = -1; ok && dmaj <= 1; dmaj++)
+        {
+            _stale(res, order, state);
+
+            _nmod_poly_mat_set_trunc_from_mat_poly(res, matp, order, kern, dmaj);
+
+            if (! _pmat_equal(ref, res))
+            {
+                flint_printf("failure with kern = %d, dmaj = %d\n", kern, dmaj);
+                ok = 0;
+            }
+        }
+
+    /* the dispatcher, and the non-truncated entry point */
+    if (ok)
+    {
+        _stale(res, order, state);
+        nmod_poly_mat_set_trunc_from_mat_poly(res, matp, order);
+        ok = _pmat_equal(ref, res);
+    }
+
+    if (ok && order >= matp->length)
+    {
+        _stale(res, order, state);
+        nmod_poly_mat_set_from_mat_poly(res, matp);
+        ok = _pmat_equal(ref, res);
+    }
+
+    /* same, into a window, whose row stride is not the number of columns */
+    if (ok && r > 1 && c > 1)
+    {
+        nmod_poly_mat_t big, win;
+        nmod_poly_mat_init(big, r + 1, c + 2, prime);
+        _stale(big, order, state);
+        nmod_poly_mat_window_init(win, big, 1, 2, 1 + r, 2 + c);
+        nmod_poly_mat_set_trunc_from_mat_poly(win, matp, order);
+        ok = _pmat_equal(ref, win);
+        nmod_poly_mat_window_clear(win);
+        nmod_poly_mat_clear(big);
+    }
+
+    nmod_poly_mat_clear(ref);
+    nmod_poly_mat_clear(res);
+    return ok;
+}
+
+/* random matrix polynomial; `zeros` asks for some coefficients to be zero,
+   including trailing ones, so that the output entries get unequal lengths */
+static void _rand_matp(nmod_mat_poly_t matp, flint_rand_t state, slong len, int zeros)
+{
+    nmod_mat_poly_rand(matp, state, len);
+    if (zeros)
+        for (slong k = 0; k < matp->length; k++)
+            for (slong i = 0; i < matp->r; i++)
+                for (slong j = 0; j < matp->c; j++)
+                    if (n_randint(state, 3) == 0 || (k + 1 == matp->length && (i + j) % 2))
+                        nmod_mat_poly_entry(matp, k, i, j) = UWORD(0);
+}
+
+TEST_FUNCTION_START(nmod_poly_mat_set_from_mat_poly, state)
+{
+    int result;
+
+    for (slong iter = 0; iter < 200 * flint_test_multiplier(); iter++)
+    {
+        const slong nbits = 2 + n_randint(state, 63);
+        const ulong prime = n_randprime(state, nbits, 1);
+
+        /* dimensions and lengths straddling the block sizes 4 and 8 */
+        const slong rdim = n_randint(state, 12);
+        const slong cdim = n_randint(state, 12);
+        const slong len = n_randint(state, 26);
+
+        nmod_mat_poly_t matp;
+        nmod_mat_poly_init(matp, rdim, cdim, prime);
+        _rand_matp(matp, state, len, n_randint(state, 2));
+
+        /* order below, at, and above the length of the input */
+        const slong order = n_randint(state, matp->length + 3);
+
+        result = core_test_set_from_mat_poly(matp, order, state);
+
+        /* same input with a row stride larger than its number of columns:
+           this takes the row-by-row path of the implementation */
+        if (result && rdim > 0 && cdim > 0)
+        {
+            nmod_mat_poly_t wide;
+            nmod_mat_poly_init(wide, rdim, cdim, prime);
+            wide->stride = cdim + 1 + n_randint(state, 8);
+            nmod_mat_poly_fit_length(wide, matp->length);
+            _nmod_mat_poly_set_length(wide, matp->length);
+            for (slong k = 0; k < matp->length; k++)
+                for (slong i = 0; i < rdim; i++)
+                    for (slong j = 0; j < cdim; j++)
+                        nmod_mat_poly_entry(wide, k, i, j) = nmod_mat_poly_entry(matp, k, i, j);
+            result = core_test_set_from_mat_poly(wide, order, state);
+            nmod_mat_poly_clear(wide);
+        }
+
+        if (!result)
+            TEST_FUNCTION_FAIL("prime = %wu, rdim = %wd, cdim = %wd, len = %wd, order = %wd\n",
+                               prime, rdim, cdim, len, order);
+
+        nmod_mat_poly_clear(matp);
+    }
+
+    /* larger instances, to reach the blocked path with both schedules */
+    {
+        const ulong prime = UWORD(1099511627791);
+        const slong shapes[4][2] = {{9, 9}, {5, 40}, {40, 5}, {16, 16}};
+        const slong orders[3] = {7, 33, 130};
+
+        for (int s = 0; s < 4; s++)
+            for (int o = 0; o < 3; o++)
+            {
+                nmod_mat_poly_t matp;
+                nmod_mat_poly_init(matp, shapes[s][0], shapes[s][1], prime);
+                _rand_matp(matp, state, orders[o], 1);
+
+                result = core_test_set_from_mat_poly(matp, orders[o], state)
+                      && core_test_set_from_mat_poly(matp, orders[o] / 2, state);
+
+                if (!result)
+                    TEST_FUNCTION_FAIL("large instance %wd x %wd, order %wd\n",
+                                       shapes[s][0], shapes[s][1], orders[o]);
+
+                nmod_mat_poly_clear(matp);
+            }
+    }
+
+    TEST_FUNCTION_END(state);
+}


### PR DESCRIPTION
We have operations that are close to matrix transposes in a few places where we need to change the data layout. Typically:
- when converting from nmod_poly_mat to nmod_mat_poly and vice versa
- in multiplication algorithms via evaluation-interpolation, in the step that evaluates an nmod_poly_mat at multiple points and stores the result as a list of nmod_mat (each one being the polynomial matrix evaluated at a point)
- and in the same algorithms, in the step that interpolates the pointwise multiplied nmod_mat's into a single nmod_poly_mat
- and in the related mulmid algorithms, etc.

In ntl-extras, using blocking had helped to achieve significantly better speed for these operations, with quite noticeable impact on polynomial matrix multiplication in some parameters regimes. This PR aims to do a similar enhancement in flint-extras, with blocking and also the incorporation of SIMD vectorized transpositions.

Implemented with the help of Claude Opus.